### PR TITLE
Add option to generate requirements from current env

### DIFF
--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -491,7 +491,7 @@ def main():
 
     parser.add_argument(
         "command",
-        choices=["generate_env", "mirror", "serve", "copy_server"],
+        choices=["generate_env", "generate_reqs", "mirror", "serve", "copy_server"],
         help="Command to execute")
 
     args = parser.parse_args()
@@ -500,6 +500,8 @@ def main():
         server.run(args.index_path, args.host, args.port)
     elif args.command == "generate_env":
         configurator.generate_env(args.env)
+    elif args.command == "generate_reqs":
+        configurator.generate_reqs(args.mode)
     elif args.command == "mirror":
         mirror(args.index_path)
     elif args.command == "copy_server":

--- a/morgan/configurator.py
+++ b/morgan/configurator.py
@@ -3,7 +3,8 @@ import configparser
 import os
 import platform
 import sys
-
+import pkg_resources
+from collections import OrderedDict
 
 def generate_env(name: str = "local"):
     """
@@ -26,6 +27,26 @@ def generate_env(name: str = "local"):
     }
     config.write(sys.stdout)
 
+def generate_reqs(mode: str = ">="):
+    """
+    Generate a requirements configuration block from current environment.
+
+    The requirements block is printed to standard output,
+    and can either be copied to the configuration file, or piped to it
+    using shell redirection (e.g. `>>`).
+
+    Args:
+        mode (str, optional):
+            Mode to use for versioning. Use "==" for exact versioning,
+            ">=" for minimum versioning, or "<=" for maximum versioning.
+            Defaults to ">=".
+    """
+    requirements = {p.project_name.lower(): f"{mode}{p.version}" \
+        for p in pkg_resources.working_set}
+    config = configparser.ConfigParser()
+    config["requirements"] = OrderedDict(sorted(requirements.items()))
+    config.write(sys.stdout)
+
 
 def add_arguments(parser: argparse.ArgumentParser):
     """
@@ -36,4 +57,11 @@ def add_arguments(parser: argparse.ArgumentParser):
         '-e', '--env',
         dest='env',
         help='Name of environment to configure'
+    )
+
+    parser.add_argument(
+        '-m', '--mode',
+        dest='mode',
+        default=">=",
+        help='Versioning mode for requirements: ">=" / "==" / "<="',
     )

--- a/morgan/configurator.py
+++ b/morgan/configurator.py
@@ -62,6 +62,7 @@ def add_arguments(parser: argparse.ArgumentParser):
     parser.add_argument(
         '-m', '--mode',
         dest='mode',
+        choices=['>=', '==', '<='],
         default=">=",
         help='Versioning mode for requirements: ">=" / "==" / "<="',
     )

--- a/morgan/configurator.py
+++ b/morgan/configurator.py
@@ -64,5 +64,5 @@ def add_arguments(parser: argparse.ArgumentParser):
         dest='mode',
         choices=['>=', '==', '<='],
         default=">=",
-        help='Versioning mode for requirements: ">=" / "==" / "<="',
+        help='Versioning mode for requirements',
     )

--- a/poetry.lock
+++ b/poetry.lock
@@ -123,6 +123,19 @@ tomli = ">=1.0.0"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
+name = "setuptools"
+version = "65.3.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -153,7 +166,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "e0d80c63f567db7b3053d88b1b6ddcd8f07422ad77fc9286e82e01e8bc739a3f"
+content-hash = "6b0513719d7f56972c3e6b752d242ce649304dcdbf6dff976aa3e620356a95e4"
 
 [metadata.files]
 attrs = [
@@ -195,6 +208,10 @@ pyparsing = [
 pytest = [
     {file = "pytest-7.1.3-py3-none-any.whl", hash = "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7"},
     {file = "pytest-7.1.3.tar.gz", hash = "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"},
+]
+setuptools = [
+    {file = "setuptools-65.3.0-py3-none-any.whl", hash = "sha256:2e24e0bec025f035a2e72cdd1961119f557d78ad331bb00ff82efb2ab8da8e82"},
+    {file = "setuptools-65.3.0.tar.gz", hash = "sha256:7732871f4f7fa58fb6bdcaeadb0161b2bd046c85905dbaa066bdcbcc81953b57"},
 ]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ license = "Apache License 2.0"
 python = "^3.7"
 packaging = "^21.3"
 pkginfo = "^1.8.3"
+setuptools = "^65.3.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.3"


### PR DESCRIPTION
This pull-request adds option to automatically generate requirements configuration block using packages from current python environment. The requirements block is printed to standard output, and can either be copied to the configuration file, or piped to it using shell redirection (e.g. `>>`). The packages are sorted alphabetically.

```bash
$ morgan generate_reqs
[requirements]
anyio = >=3.6.1
appdirs = >=1.4.4
appnope = >=0.1.2
apptools = >=5.2.0
...
```

The `--mode` argument is used for precise versioning: `">=" / "==" / "<="` 

```bash
$ morgan generate_reqs -m "=="
[requirements]
anyio = ==3.6.1
appdirs = ==1.4.4
appnope = ==0.1.2
apptools = ==5.2.0
...
```

This PR would be handy, if you want to maintain (and update regularly) a PYPI mirror with packages similar to your work environment on your online machine. 