### PR TITLE
Fix supported platforms regex

### DIFF
--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -57,7 +57,7 @@ class Mirrorer:
                 self.envs[m.group(1)] = dict(env)
                 self._supported_pyversions.append(env["python_version"])
                 self._supported_platforms.append(
-                    re.compile("r.*" +
+                    re.compile(r".*" +
                                env["sys_platform"] +
                                r".*" +
                                env["platform_machine"]))


### PR DESCRIPTION
This was preventing (many)linux wheels from downloading (and probably other wheels?), since there was an unintentional leading `r` in the regex.