### PR TITLE
Fix pkg name retrieval in generate_reqs

### DIFF
--- a/morgan/configurator.py
+++ b/morgan/configurator.py
@@ -49,7 +49,7 @@ def generate_reqs(mode: str = ">="):
             ">=" for minimum versioning, or "<=" for maximum versioning.
             Defaults to ">=".
     """
-    requirements = {dist.name.lower(): f"{mode}{dist.version}"
+    requirements = {dist.metadata["Name"].lower(): f"{mode}{dist.version}"
                     for dist in metadata.distributions()}
     config = configparser.ConfigParser()
     config["requirements"] = OrderedDict(sorted(requirements.items()))


### PR DESCRIPTION
This pull request fixes the `AttributeError: 'PathDistribution' object has no attribute 'name'` when running command `morgan generate_reqs`. According to the `importlib-metadata~=4.12.0` [documentation](https://docs.python.org/3/library/importlib.metadata.html#metadata):

```python
import importlib.metadata

names = [dist.metadata['Name'] for disc in Importlib.metadata.distributions()]
```


