### PR TITLE
Decode request URLs before handling

### DIFF
--- a/morgan/server.py
+++ b/morgan/server.py
@@ -27,7 +27,7 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
     """
 
     def do_GET(self):
-        url = urllib.parse.urlsplit(self.path)
+        url = urllib.parse.urlsplit(urllib.parse.unquote(self.path))
 
         ct = parse_accept_header(self.headers.get("Accept"))
         if ct is None:


### PR DESCRIPTION
Variants of some packages (e.g. [CPU-only builds](https://download.pytorch.org/whl/cpu) of PyTorch) may have characters in their filenames that get percent-encoded. In the given example, `+` gets encoded to `%2B`. When pip asks for these filenames, (at least on my machine) it uses percent-encoded URLs in its requests to the morgan server. The server however does not decode these URLs, so it just returns a 404.

Pass the URL to `urllib.parse.unquote` before `urllib.parse.unsplit` to fix this. I'm not sure this is the best way to fix it, but it was the easiest. It might make more sense to instead `unquote` just the path portion of the URL after `urlsplit` instead of the entire thing.

Note: I did not use morgan itself to retrieve the packages that had those special characters since they were outside of PyPI, and I haven't really looked for an applicable example inside PyPI. I think the idea still applies though, since AFAIK pip will `quote` any URLs it sends.