### PR TITLE
Add platform tag to environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,10 @@ Environment configuration blocks can be automatically generated via
 
 ```ini
 [env.legacy]
-python_version = 3.7
-python_full_version = 3.7.7
+python_version = 3.9
+python_full_version = 3.9.9
 os_name = posix
+platform_tag = linux-x86_64
 sys_platform = linux
 platform_machine = i686
 platform_python_implementation = CPython
@@ -110,12 +111,13 @@ implementation_name = cpython
 
 [env.edge]
 os_name = posix
+platform_tag = linux-x86_64
 sys_platform = linux
 platform_machine = x86_64
 platform_python_implementation = CPython
 platform_system = Linux
-python_version = 3.10
-python_full_version = 3.10.6
+python_version = 3.12
+python_full_version = 3.12.7
 implementation_name = cpython
 
 [requirements]

--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -57,10 +57,7 @@ class Mirrorer:
                 self.envs[m.group(1)] = dict(env)
                 self._supported_pyversions.append(env["python_version"])
                 self._supported_platforms.append(
-                    re.compile(r".*" +
-                               env["sys_platform"] +
-                               r".*" +
-                               env["platform_machine"]))
+                    re.compile(env["platform_tag"]))
 
         self._processed_pkgs = {}
 

--- a/morgan/configurator.py
+++ b/morgan/configurator.py
@@ -4,6 +4,7 @@ import configparser
 import os
 import platform
 import sys
+import sysconfig
 
 from packaging.version import Version
 
@@ -24,6 +25,7 @@ def generate_env(name: str = "local"):
     config = configparser.ConfigParser()
     config["env.{}".format(name)] = {
         'os_name': os.name,
+        'platform_tag': sysconfig.get_platform(),
         'sys_platform': sys.platform,
         'platform_machine': platform.machine(),
         'platform_python_implementation': platform.python_implementation(),


### PR DESCRIPTION
I have been using morgan script on both Windows 11 and Linux (Fedora and Debian) OSes.  I noticed that it was looking for the wrong platform tag in the file name when looking for Windows wheels.  So I edited the configurator and the mirrorer, so it uses sysconfig.get_platform() based on the [PyPA specifications](https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/).