### PR TITLE
Add env variable to configure pypi address

### DIFF
--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -21,7 +21,7 @@ import packaging.version
 from morgan import configurator, metadata, server
 from morgan.__about__ import __version__
 
-PYPI_ADDRESS = "https://pypi.org/simple/"
+PYPI_ADDRESS = os.getenv("MORGAN_PYPI_ADDRESS", "https://pypi.org/simple/")
 PREFERRED_HASH_ALG = "sha256"
 
 


### PR DESCRIPTION
I have a usecase where I want to control the access to different packages into a offline environment. In that case, the access to PYPI is provided through a proxy. For that usecase, having the pypi address as a environment variable enables the usage of such a proxy.