### PR TITLE
Change platform_tag config to be optional

### DIFF
--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -58,7 +58,8 @@ class Mirrorer:
                 env["extra"] = ""
                 self.envs[m.group(1)] = dict(env)
                 self._supported_pyversions.append(env["python_version"])
-                self._supported_platforms.append(re.compile(env["platform_tag"]))
+                if "platform_tag" in env:
+                    self._supported_platforms.append(re.compile(env["platform_tag"]))
                 self._supported_platforms.append(
                     re.compile(
                         r".*" + env["sys_platform"] + r".*" + env["platform_machine"]


### PR DESCRIPTION
The new `platform_tag` option in v0.14.0 is nice, but it breaks dozens of mirror configs I already have, and I don't really want to edit each of them just to add a single option.

This PR makes the new config optional.