### PR TITLE
packaging: ~=21.3 -> ~=24.2

### DIFF
--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -215,7 +215,12 @@ class Mirrorer:
                     )
                     file["is_wheel"] = False
                     file["tags"] = None
-            except packaging.version.InvalidVersion:
+            except (packaging.version.InvalidVersion,
+                    packaging.utils.InvalidSdistFilename,
+                    packaging.utils.InvalidWheelFilename):
+                # old versions
+                # expandvars-0.6.0-macosx-10.15-x86_64.tar.gz
+
                 # ignore files with invalid version, PyPI no longer allows
                 # packages with special versioning schemes, and we assume we
                 # can ignore such files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,11 @@ keywords = [ "pypi", "mirror", "packages", "pypi-mirror" ]
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
-    "packaging~=21.3",
+    #"packaging~=21.3",
+        # hatchling 1.27.0 requires packaging>=24.2, but you have packaging 21.3 which is incompatible.
+    "packaging~=24.2",
+        # packaging.utils.InvalidSdistFilename: Invalid sdist filename (invalid version): 'expandvars-0.6.0-macosx-10.15-x86_64.tar.gz' (old versions)
+        # solved in morgan/__init__.py
     "importlib-metadata~=4.12.0; python_version < '3.8'",
     "tomli~=2.0.1",
 ]


### PR DESCRIPTION
avoid warning from hatchling
```
python3 -m venv .venv
. .venv/bin/activate
python -m pip install .
...
hatchling 1.27.0 requires packaging>=24.2, but you have packaging 21.3 which is incompatible.
```