### PR TITLE
More generously match interpreter version

### DIFF
--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -298,10 +298,22 @@ class Mirrorer:
                 (intrp_name, intrp_ver) = parse_interpreter(tag.interpreter)
                 if intrp_name not in ("py", "cp"):
                     continue
+
+                intrp_set = packaging.specifiers.SpecifierSet(r'>=' + intrp_ver)
+                # As an example, cp38 seems to indicate CPython 3.8+, so we
+                # check if the version matches any of the supported Pythons, and
+                # only skip it if it does not match any.
+                intrp_ver_matched = any(
+                    map(
+                        lambda supported_python: intrp_set.contains(supported_python),
+                        self._supported_pyversions,
+                    )
+                )
+
                 if (
                     intrp_ver
                     and intrp_ver != "3"
-                    and intrp_ver not in self._supported_pyversions
+                    and not intrp_ver_matched
                 ):
                     continue
 


### PR DESCRIPTION
I was having issues trying to mirror the `nh3` package and noticed that the CPython wheel uploaded was tagged with `cp38`, which pip normally downloaded for CPython 3.9. Further examining the exact files of the `nh3` library, the [files tagged with `cp38` seems to be noted to work with CPython 3.8+](https://pypi.org/project/nh3/#files).

I think this might also fix [this issue](https://github.com/ido50/morgan/issues/36).

However, I am uncertain this is the right solution. Perhaps it is the `abi3` part which makes that CPython wheel more adaptable? I am not soon learned on the intricacies of Python packaging, tbh. Anyways, I my usecase, mirroring a few wheels extra seems like a OK compromise to have them available when/if `pip` decides to fetch them.