### PR TITLE
add cache for simple requirements: pkg, pkg>1.2, pkg>=1.2.3

### DIFF
--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -20,7 +20,7 @@ import packaging.version
 
 from morgan import configurator, metadata, server
 from morgan.__about__ import __version__
-from morgan.utils import to_single_dash
+from morgan.utils import Cache, to_single_dash
 
 PYPI_ADDRESS = "https://pypi.org/simple/"
 PREFERRED_HASH_ALG = "sha256"
@@ -66,7 +66,7 @@ class Mirrorer:
                     )
                 )
 
-        self._processed_pkgs = {}
+        self._processed_pkgs = Cache()
 
     def mirror(self, requirement_string: str):
         """
@@ -122,8 +122,7 @@ class Mirrorer:
         requirement: packaging.requirements.Requirement,
         required_by: packaging.requirements.Requirement = None,
     ) -> dict:
-        req_str = str(requirement)
-        if req_str in self._processed_pkgs:
+        if self._processed_pkgs.check(requirement):
             return None
 
         if required_by:
@@ -184,7 +183,7 @@ class Mirrorer:
                 traceback.print_exc()
                 continue
 
-        self._processed_pkgs[req_str] = True
+        self._processed_pkgs.add(requirement)
 
         return depdict
 

--- a/morgan/utils.py
+++ b/morgan/utils.py
@@ -1,5 +1,8 @@
 import re
 
+from packaging.requirements import Requirement
+
+
 def to_single_dash(filename):
     'https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers'
 
@@ -14,3 +17,28 @@ def to_single_dash(filename):
         filename = filename[:m.start() + 1] + s2
     return filename
     # selenium-2.0.dev9429.tar.gz
+
+
+class Cache:  # pylint: disable=protected-access
+    def __init__(self):
+        self.cache: set[str] = set()
+
+    def check(self, req: Requirement) -> bool:
+        if self.is_simple_case(req):
+            return req.name in self.cache
+        return str(req) in self.cache
+
+    def add(self, req: Requirement):
+        if self.is_simple_case(req):
+            self.cache.add(req.name)
+        else:
+            self.cache.add(str(req))
+
+    def is_simple_case(self, req):
+        if not req.marker and not req.extras:
+            specifier = req.specifier
+            if not specifier:
+                return True
+            if all(spec.operator in ('>', '>=') for spec in specifier._specs):
+                return True
+        return False


### PR DESCRIPTION
All the requirements: pkg, pkg>1.2, pkg>=1.2.3
yield the same outcome: pkg-<max version>.
So they can be cached.