### PR TITLE
add argument to skip server copy

### DIFF
--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -494,7 +494,9 @@ def mirror(args: argparse.Namespace):
             for req in reqs:
                 req = req.strip()
                 m.mirror(f"{package}{req}")
-    m.copy_server()
+
+    if not args.skip_server_copy:
+        m.copy_server()
 
 
 def main():
@@ -537,6 +539,12 @@ def main():
         dest="config",
         nargs="?",
         help="Config file (default: <INDEX_PATH>/morgan.ini)",
+    )
+    parser.add_argument(
+        "--skip-server-copy",
+        dest="skip_server_copy",
+        action="store_true",
+        help="Skip server copy in mirror command (default: False)",
     )
 
     server.add_arguments(parser)


### PR DESCRIPTION
I intend to use Morgan only as a package mirroring tool.
Because of this, I would like to add another argument to disable the server script copy feature in `mirror()`.

About the naming, I'm not quite sure.

To keep changes low, I use `--skip-server-copy` here.
Even though I would prefer to just call it `--copy-server-script` to prevent the negation and write something like this in the if-check

```python
if args.copy_server_script:
    m.copy_server()
```

But writing it this way would break compatibility of the current command line user interface due to requiring this argument explicitly to copy the server script over to the index directory.
