### PR TITLE
add argument to allow download a range of versions of a package

### DIFF
--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -361,7 +361,11 @@ class Mirrorer:
         depdict = {}
         for dep in deps:
             dep.name = packaging.utils.canonicalize_name(dep.name)
-            depdict[dep.name] = {
+            # keep the index of the dictionary for the full requirement string to pull in potentially
+            # duplicate requirements like "mylibrary<2,>=1" and "mylibrary>=2,<3" that may come from different
+            # top-level requirements
+            dep_index = str(dep)
+            depdict[dep_index] = {
                 "requirement": dep,
                 "required_by": requirement,
             }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -152,9 +152,9 @@ class TestMirrorer:
 
 class TestFilterFiles:
     @pytest.fixture
-    def temp_index_path(self, tmpdir):
+    def temp_index_path(self, tmp_path):
         # Create minimal config file
-        config_path = os.path.join(tmpdir, "morgan.ini")
+        config_path = os.path.join(tmp_path, "morgan.ini")
         with open(config_path, "w", encoding="utf-8") as f:
             f.write(
                 """
@@ -165,7 +165,7 @@ class TestFilterFiles:
                 platform_tag = manylinux
                 """
             )
-        yield tmpdir
+        yield tmp_path
 
     @pytest.fixture
     def make_mirrorer(self, temp_index_path):


### PR DESCRIPTION
I would like to add an argument to allow the download of a range of versions of packages.

This approach works like a simple switch and keeps the default functionality untouched.

It's important to note that this changes the dependency resolution of multiple packages.
- Previously, when multiple versions were defined of a single package, it pulled in the intersection of both sets of requirements/dependencies.
- With this change, it will pull in the union of both sets of requirements/dependencies instead. This means, you can pull a large range of package versions and have the full dependency trees of each version.