### PR TITLE
Add basic Github Action 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Enable version updates for Github-Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,18 @@
+---
+name: Python Linting
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+jobs:
+  black:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: psf/black@af0ba72a73598c76189d6dd1b21d8532255d5942 # v25.9.0

--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -215,9 +215,11 @@ class Mirrorer:
                     )
                     file["is_wheel"] = False
                     file["tags"] = None
-            except (packaging.version.InvalidVersion,
-                    packaging.utils.InvalidSdistFilename,
-                    packaging.utils.InvalidWheelFilename):
+            except (
+                packaging.version.InvalidVersion,
+                packaging.utils.InvalidSdistFilename,
+                packaging.utils.InvalidWheelFilename,
+            ):
                 # old versions
                 # expandvars-0.6.0-macosx-10.15-x86_64.tar.gz
 
@@ -280,7 +282,7 @@ class Mirrorer:
             # packaging.specifiers.SpecifierSet(req): Invalid specifier
             # gssapi: Invalid specifier: '>=3.6.*'
             # pyzmq: Invalid specifier: '!=3.0*'
-            req = fileinfo["requires-python"] = re.sub(r'([0-9])\.?\*', r'\1', req)
+            req = fileinfo["requires-python"] = re.sub(r"([0-9])\.?\*", r"\1", req)
             try:
                 spec_set = packaging.specifiers.SpecifierSet(req)
                 for supported_python in self._supported_pyversions:
@@ -299,7 +301,7 @@ class Mirrorer:
                 if intrp_name not in ("py", "cp"):
                     continue
 
-                intrp_set = packaging.specifiers.SpecifierSet(r'>=' + intrp_ver)
+                intrp_set = packaging.specifiers.SpecifierSet(r">=" + intrp_ver)
                 # As an example, cp38 seems to indicate CPython 3.8+, so we
                 # check if the version matches any of the supported Pythons, and
                 # only skip it if it does not match any.
@@ -310,11 +312,7 @@ class Mirrorer:
                     )
                 )
 
-                if (
-                    intrp_ver
-                    and intrp_ver != "3"
-                    and not intrp_ver_matched
-                ):
+                if intrp_ver and intrp_ver != "3" and not intrp_ver_matched:
                     continue
 
                 if tag.platform == "any":

--- a/morgan/configurator.py
+++ b/morgan/configurator.py
@@ -8,7 +8,7 @@ import sysconfig
 
 from packaging.version import Version
 
-if Version(platform.python_version()) < Version('3.8'):
+if Version(platform.python_version()) < Version("3.8"):
     import importlib_metadata as metadata
 else:
     import importlib.metadata as metadata
@@ -24,15 +24,15 @@ def generate_env(name: str = "local"):
 
     config = configparser.ConfigParser()
     config["env.{}".format(name)] = {
-        'os_name': os.name,
-        'platform_tag': sysconfig.get_platform(),
-        'sys_platform': sys.platform,
-        'platform_machine': platform.machine(),
-        'platform_python_implementation': platform.python_implementation(),
-        'platform_system': platform.system(),
-        'python_version': '.'.join(platform.python_version_tuple()[:2]),
-        'python_full_version': platform.python_version(),
-        'implementation_name': sys.implementation.name,
+        "os_name": os.name,
+        "platform_tag": sysconfig.get_platform(),
+        "sys_platform": sys.platform,
+        "platform_machine": platform.machine(),
+        "platform_python_implementation": platform.python_implementation(),
+        "platform_system": platform.system(),
+        "python_version": ".".join(platform.python_version_tuple()[:2]),
+        "python_full_version": platform.python_version(),
+        "implementation_name": sys.implementation.name,
     }
     config.write(sys.stdout)
 
@@ -51,8 +51,10 @@ def generate_reqs(mode: str = ">="):
             ">=" for minimum versioning, or "<=" for maximum versioning.
             Defaults to ">=".
     """
-    requirements = {dist.metadata["Name"].lower(): f"{mode}{dist.version}"
-                    for dist in metadata.distributions()}
+    requirements = {
+        dist.metadata["Name"].lower(): f"{mode}{dist.version}"
+        for dist in metadata.distributions()
+    }
     config = configparser.ConfigParser()
     config["requirements"] = OrderedDict(sorted(requirements.items()))
     config.write(sys.stdout)
@@ -64,15 +66,14 @@ def add_arguments(parser: argparse.ArgumentParser):
     """
 
     parser.add_argument(
-        '-e', '--env',
-        dest='env',
-        help='Name of environment to configure'
+        "-e", "--env", dest="env", help="Name of environment to configure"
     )
 
     parser.add_argument(
-        '-m', '--mode',
-        dest='mode',
-        choices=['>=', '==', '<='],
+        "-m",
+        "--mode",
+        dest="mode",
+        choices=[">=", "==", "<="],
         default=">=",
-        help='Versioning mode for requirements',
+        help="Versioning mode for requirements",
     )

--- a/morgan/metadata.py
+++ b/morgan/metadata.py
@@ -111,7 +111,9 @@ class MetadataParser:
             if re.fullmatch(r"[^/]+/PKG-INFO", filename):
                 parse_func = self._parse_metadata_file
                 main_metadata_file = True
-            elif re.fullmatch(r"[^/]+(/[^/]+)?\.egg-info/(setup_)?requires.txt", filename):
+            elif re.fullmatch(
+                r"[^/]+(/[^/]+)?\.egg-info/(setup_)?requires.txt", filename
+            ):
                 parse_func = self._parse_requirestxt
             elif re.fullmatch(r"[^/]+/pyproject.toml", filename):
                 parse_func = self._parse_pyproject
@@ -144,9 +146,7 @@ class MetadataParser:
             out.write(self._metadata_file)
 
     def dependencies(
-        self,
-        extras: Set[str] = set(),
-        envs: Iterable[Dict] = []
+        self, extras: Set[str] = set(), envs: Iterable[Dict] = []
     ) -> Set[Requirement]:
         """
         Resolves the dependencies of the package, returning a set of
@@ -215,8 +215,7 @@ class MetadataParser:
     def _add_optional_requirements(self, extra, reqs):
         if extra not in self.optional_dependencies:
             self.optional_dependencies[extra] = set()
-        self.optional_dependencies[extra] |= set(
-            [Requirement(dep) for dep in reqs])
+        self.optional_dependencies[extra] |= set([Requirement(dep) for dep in reqs])
 
     def _parse_pyproject(self, fp):
         data = tomli.load(fp)
@@ -232,8 +231,7 @@ class MetadataParser:
                 self.version = Version(version)
 
             if "requires-python" in project:
-                self.python_requirement = SpecifierSet(
-                    project["requires-python"])
+                self.python_requirement = SpecifierSet(project["requires-python"])
 
             if "dependencies" in project:
                 self._add_core_requirements(project["dependencies"])
@@ -241,19 +239,23 @@ class MetadataParser:
             if "optional-dependencies" in project:
                 for extra in project["optional-dependencies"]:
                     self._add_optional_requirements(
-                        extra, project["optional-dependencies"][extra])
+                        extra, project["optional-dependencies"][extra]
+                    )
 
         build_system = data.get("build-system")
         if build_system is not None and "requires" in build_system:
             self.build_dependencies |= set(
-                [Requirement(req) for req in build_system["requires"]])
+                [Requirement(req) for req in build_system["requires"]]
+            )
 
     def _parse_metadata_file(self, fp):
         data = email.parser.BytesParser().parse(fp, True)
 
-        (name, version, metadata_version) = (data.get("Name"),
-                                             data.get("Version"),
-                                             data.get("Metadata-Version"))
+        (name, version, metadata_version) = (
+            data.get("Name"),
+            data.get("Version"),
+            data.get("Metadata-Version"),
+        )
         if metadata_version is None:
             return
 
@@ -288,8 +290,10 @@ class MetadataParser:
                 extra = None
                 if req.marker is not None:
                     for marker in req.marker._markers:
-                        if isinstance(marker[0], MarkerVariable) and \
-                                marker[0].value == "extra":
+                        if (
+                            isinstance(marker[0], MarkerVariable)
+                            and marker[0].value == "extra"
+                        ):
                             extra = marker[2].value
                             break
 

--- a/morgan/server.py
+++ b/morgan/server.py
@@ -7,10 +7,10 @@ import pathlib
 import re
 import urllib.parse
 
-PYPI_JSON_TYPE_V1 = 'application/vnd.pypi.simple.v1+json'
-PYPI_JSON_TYPE_LT = 'application/vnd.pypi.simple.latest+json'
-PYPI_HTML_TYPE_V1 = 'application/vnd.pypi.simple.v1+html'
-GENL_HTML_TYPE = 'text/html'
+PYPI_JSON_TYPE_V1 = "application/vnd.pypi.simple.v1+json"
+PYPI_JSON_TYPE_LT = "application/vnd.pypi.simple.latest+json"
+PYPI_HTML_TYPE_V1 = "application/vnd.pypi.simple.v1+html"
+GENL_HTML_TYPE = "text/html"
 
 project_re = re.compile(r"/([^/]+)/")
 file_re = re.compile(r"/([^/]+)/([^/]+)")
@@ -36,8 +36,9 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
             self.send_header("Content-Type", "text/plain")
             self.end_headers()
             self.wfile.write(
-                b"The server cannot generate a response " +
-                b"in any of the requested MIME types")
+                b"The server cannot generate a response "
+                + b"in any of the requested MIME types"
+            )
             return
 
         if url[2] in ["", "/"]:
@@ -77,23 +78,19 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_header("Content-Type", PYPI_JSON_TYPE_V1)
             self.end_headers()
-            body = json.dumps({
-                "meta": {"api-version": "1.0"},
-                "projects": projects
-            })
+            body = json.dumps({"meta": {"api-version": "1.0"}, "projects": projects})
             self.wfile.write(body.encode("utf-8"))
         else:
             self.send_response(200)
             self.send_header("Content-Type", ct)
             self.end_headers()
-            self.wfile.write(
-                b"<!DOCTYPE html>\n<html>\n  <body>\n")
-            for (i, project) in enumerate(projects):
+            self.wfile.write(b"<!DOCTYPE html>\n<html>\n  <body>\n")
+            for i, project in enumerate(projects):
                 newline = "\n" if i < len(projects) - 1 else ""
                 self.wfile.write(
-                    "    <a href=\"/{}/\">{}</a>{}".format(
-                        html.escape(project["name"]),
-                        project["name"], newline).encode("utf-8"),
+                    '    <a href="/{}/">{}</a>{}'.format(
+                        html.escape(project["name"]), project["name"], newline
+                    ).encode("utf-8"),
                 )
             self.wfile.write(b"\n  </body>\n</html>")
 
@@ -124,10 +121,11 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
                             file["hashes"][data[0]] = data[1]
 
                     # do we have a metadata file?
-                    file["dist-info-metadata"] = False if no_metadata \
-                        else path.joinpath(
-                            "{}.metadata".format(entry.name)
-                        ).exists()
+                    file["dist-info-metadata"] = (
+                        False
+                        if no_metadata
+                        else path.joinpath("{}.metadata".format(entry.name)).exists()
+                    )
 
                     files.append(file)
         files.sort(key=lambda file: file["filename"])
@@ -136,40 +134,38 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_header("Content-Type", PYPI_JSON_TYPE_V1)
             self.end_headers()
-            body = json.dumps({
-                "name": project,
-                "meta": {"api-version": "1.0"},
-                "files": files
-            })
+            body = json.dumps(
+                {"name": project, "meta": {"api-version": "1.0"}, "files": files}
+            )
             self.wfile.write(body.encode("utf-8"))
         else:
             self.send_response(200)
             self.send_header("Content-Type", ct)
             self.end_headers()
-            self.wfile.write(
-                b"<!DOCTYPE html>\n<html>\n  <body>\n")
-            for (i, file) in enumerate(files):
+            self.wfile.write(b"<!DOCTYPE html>\n<html>\n  <body>\n")
+            for i, file in enumerate(files):
                 newline = "\n" if i < len(files) - 1 else ""
                 hashval = ""
                 if "sha256" in file["hashes"]:
-                    hashval = "#{}={}".format(
-                        "sha256", file["hashes"]["sha256"])
+                    hashval = "#{}={}".format("sha256", file["hashes"]["sha256"])
                 if not no_metadata and file.get("dist-info-metadata", False):
                     self.wfile.write(
-                        "    <a href=\"{}{}\" data-dist-info-metadata=\"true\">{}</a>{}".format(
-                                file["url"],
-                                hashval,
-                                file["filename"],
-                                newline,
-                        ).encode("utf-8"),
+                        '    <a href="{}{}" data-dist-info-metadata="true">{}</a>{}'.format(
+                            file["url"],
+                            hashval,
+                            file["filename"],
+                            newline,
+                        ).encode(
+                            "utf-8"
+                        ),
                     )
                 else:
                     self.wfile.write(
-                        "    <a href=\"{}{}\">{}</a>{}".format(
-                                file["url"],
-                                hashval,
-                                file["filename"],
-                                newline,
+                        '    <a href="{}{}">{}</a>{}'.format(
+                            file["url"],
+                            hashval,
+                            file["filename"],
+                            newline,
                         ).encode("utf-8"),
                     )
             self.wfile.write(b"\n  </body>\n</html>")
@@ -246,7 +242,7 @@ def parse_accept_header(header_val: str) -> str:
             PYPI_JSON_TYPE_V1,
             PYPI_JSON_TYPE_LT,
             PYPI_HTML_TYPE_V1,
-            GENL_HTML_TYPE
+            GENL_HTML_TYPE,
         ]:
             return option["mime"]
 
@@ -272,7 +268,7 @@ def parse_accept_option(option: str) -> dict:
 
     return {
         "mime": m.group(1).strip(),
-        "priority": float(m.group(2)) if m.lastindex == 2 else 0
+        "priority": float(m.group(2)) if m.lastindex == 2 else 0,
     }
 
 
@@ -290,34 +286,37 @@ def add_arguments(parser: argparse.ArgumentParser):
     """
 
     parser.add_argument(
-        '-H', '--host',
-        dest='host',
-        default='0.0.0.0',
-        help='Host to listen on',
+        "-H",
+        "--host",
+        dest="host",
+        default="0.0.0.0",
+        help="Host to listen on",
     )
     parser.add_argument(
-        '-p', '--port',
-        dest='port',
+        "-p",
+        "--port",
+        dest="port",
         default=8080,
         type=int,
-        help='Port to listen on',
+        help="Port to listen on",
     )
     parser.add_argument(
-        '--no-metadata',
-        action='store_true',
-        dest='no_metadata',
+        "--no-metadata",
+        action="store_true",
+        dest="no_metadata",
         default=False,
-        help='Do not serve metadata files',
+        help="Do not serve metadata files",
     )
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Morgan PyPI Server")
     parser.add_argument(
-        '-i', '--index-path',
-        dest='index_path',
+        "-i",
+        "--index-path",
+        dest="index_path",
         default=os.getcwd(),
-        help='Path to the package index',
+        help="Path to the package index",
     )
     add_arguments(parser)
     args = parser.parse_args()

--- a/morgan/utils.py
+++ b/morgan/utils.py
@@ -1,16 +1,17 @@
 import re
 
+
 def to_single_dash(filename):
-    'https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers'
+    "https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers"
 
     # selenium-2.0-dev-9429.tar.gz
-    m = re.search(r'-[0-9].*-', filename)
+    m = re.search(r"-[0-9].*-", filename)
     if m:
-        s2 = filename[m.start() + 1:]
+        s2 = filename[m.start() + 1 :]
         # 2.0-dev-9429.tar.gz
-        s2 = s2.replace('-dev-', '.dev')
+        s2 = s2.replace("-dev-", ".dev")
         # 2.0.dev9429.tar.gz
-        s2 = s2.replace('-', '.')
-        filename = filename[:m.start() + 1] + s2
+        s2 = s2.replace("-", ".")
+        filename = filename[: m.start() + 1] + s2
     return filename
     # selenium-2.0.dev9429.tar.gz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,5 +55,4 @@ path = "morgan/__about__.py"
 morgan = "morgan:main"
 
 [tool.black]
-line-length = 80
 target-version = ['py37']

--- a/tests/server.py
+++ b/tests/server.py
@@ -6,29 +6,26 @@ from morgan import server
 @pytest.mark.parametrize(
     "accept_option, exp_dict",
     [
-        (
-            server.GENL_HTML_TYPE,
-            {"mime": server.GENL_HTML_TYPE, "priority": 0}
-        ),
+        (server.GENL_HTML_TYPE, {"mime": server.GENL_HTML_TYPE, "priority": 0}),
         (
             "{};q=1".format(server.GENL_HTML_TYPE),
-            {"mime": server.GENL_HTML_TYPE, "priority": 1}
+            {"mime": server.GENL_HTML_TYPE, "priority": 1},
         ),
         (
             "{};q=0.9".format(server.GENL_HTML_TYPE),
-            {"mime": server.GENL_HTML_TYPE, "priority": 0.9}
+            {"mime": server.GENL_HTML_TYPE, "priority": 0.9},
         ),
         (
             "{} ; q=0.9".format(server.GENL_HTML_TYPE),
-            {"mime": server.GENL_HTML_TYPE, "priority": 0.9}
+            {"mime": server.GENL_HTML_TYPE, "priority": 0.9},
         ),
         (
             "{};q=0.9&charset=UTF-8".format(server.GENL_HTML_TYPE),
-            {"mime": server.GENL_HTML_TYPE, "priority": 0.9}
+            {"mime": server.GENL_HTML_TYPE, "priority": 0.9},
         ),
         (
             "{};charset=UTF-8&q=0.9".format(server.GENL_HTML_TYPE),
-            {"mime": server.GENL_HTML_TYPE, "priority": 0.9}
+            {"mime": server.GENL_HTML_TYPE, "priority": 0.9},
         ),
     ],
 )
@@ -40,10 +37,7 @@ def test_parse_accept_option(accept_option, exp_dict):
 @pytest.mark.parametrize(
     "accept_header, exp_mime",
     [
-        (
-            None,
-            server.PYPI_HTML_TYPE_V1
-        ),
+        (None, server.PYPI_HTML_TYPE_V1),
         (
             "text/xml",
             None,
@@ -53,9 +47,8 @@ def test_parse_accept_option(accept_option, exp_dict):
             server.PYPI_JSON_TYPE_V1,
         ),
         (
-            "{};q=0.5, {}; q=1".format(
-                server.PYPI_JSON_TYPE_V1, server.GENL_HTML_TYPE),
-            server.GENL_HTML_TYPE
+            "{};q=0.5, {}; q=1".format(server.PYPI_JSON_TYPE_V1, server.GENL_HTML_TYPE),
+            server.GENL_HTML_TYPE,
         ),
         (
             "*/*",


### PR DESCRIPTION
This is a basic CI for checking formatting with black, together with a dependabot configuration to keep it updated.
I will try to expand it using ruff or pylint or flake8 in the coming days.

I removed the line-length of 80 from the pyproject.toml, as it reduced the changes down to 60% (182 vs 117 inserts):

With a line-length of 80:
```
All done! ✨ 🍰 ✨
5 files reformatted, 2 files left unchanged.
 morgan/__init__.py     |  91 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++--------------------------
 morgan/configurator.py |  39 ++++++++++++++++++++-------------------
 morgan/metadata.py     |  34 +++++++++++++++++++++-------------
 morgan/server.py       | 115 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-----------------------------------------------------
 morgan/utils.py        |  13 +++++++------
 pyproject.toml         |   7 +++++++
 6 files changed, 182 insertions(+), 117 deletions(-)
```


With black's default (=88):
```
All done! ✨ 🍰 ✨
5 files reformatted, 2 files left unchanged.
 morgan/__init__.py     |  18 ++++++++----------
 morgan/configurator.py |  39 ++++++++++++++++++++-------------------
 morgan/metadata.py     |  34 +++++++++++++++++++---------------
 morgan/server.py       | 113 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++---------------------------------------------------------
 morgan/utils.py        |  13 +++++++------
 pyproject.toml         |   8 +++++++-
 6 files changed, 117 insertions(+), 108 deletions(-)
```