### PR TITLE
fix dangerous default values

### DIFF
--- a/morgan/metadata.py
+++ b/morgan/metadata.py
@@ -145,8 +145,8 @@ class MetadataParser:
 
     def dependencies(
         self,
-        extras: Set[str] = set(),
-        envs: Iterable[Dict] = []
+        extras: Set[str],
+        envs: Iterable[Dict]
     ) -> Set[Requirement]:
         """
         Resolves the dependencies of the package, returning a set of


### PR DESCRIPTION
Using mutable values as a default value does not clear the value when calling the function mutliple times, leading to invalid values of extras and envs.

As the current code does not use the default values of `dependencies()`, removing them is the best approach here.

See:
```python
#!/usr/bin/env python3
import random
from typing import Set, List, Dict, Any

class MetadataParser:
    def dependencies(
        self,
        extras: Set[str] = set(),
        envs: List[Dict] = []
    ) -> Set[Any]:
        randomint = str(random.randint(1,100000))
        extras.add("extra"+randomint)
        envs.append("env"+randomint)
        print(extras)
        print (envs)
        return extras

for i in range(3):
    MetadataParser().dependencies()
```

will return:
```
{'extra37856'}
['env37856']
{'extra37856', 'extra61676'}
['env37856', 'env61676']
{'extra37856', 'extra3307', 'extra61676'}
['env37856', 'env61676', 'env3307']
```