### PR TITLE
allow duplicate requirements in the morgan.ini file

### DIFF
--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -20,11 +20,10 @@ import packaging.version
 
 from morgan import configurator, metadata, server
 from morgan.__about__ import __version__
-from morgan.utils import to_single_dash
+from morgan.utils import ListExtendingOrderedDict, to_single_dash
 
 PYPI_ADDRESS = "https://pypi.org/simple/"
 PREFERRED_HASH_ALG = "sha256"
-
 
 class Mirrorer:
     """
@@ -43,7 +42,12 @@ class Mirrorer:
         # into representations that are easier for the mirrorer to work with
         self.index_path = args.index_path
         self.index_url = args.index_url
-        self.config = configparser.ConfigParser()
+        if args.enforce_unique_requirements:
+            self.config = configparser.ConfigParser(strict=True)
+        else:
+            self.config = configparser.ConfigParser(
+                strict=False, dict_type=ListExtendingOrderedDict
+            )
         self.config.read(args.config)
         self.envs = {}
         self._supported_pyversions = []
@@ -537,6 +541,15 @@ def main():
         dest="config",
         nargs="?",
         help="Config file (default: <INDEX_PATH>/morgan.ini)",
+    )
+    parser.add_argument(
+        "--enforce-unique-requirements",
+        dest="enforce_unique_requirements",
+        action="store_true",
+        help=(
+            "Fail if a package appears more than once in the requirements section of a morgan.ini file "
+            "(default: accumulate all requirements)"
+        ),
     )
 
     server.add_arguments(parser)

--- a/morgan/utils.py
+++ b/morgan/utils.py
@@ -1,4 +1,6 @@
 import re
+from collections import OrderedDict
+
 
 def to_single_dash(filename):
     'https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers'
@@ -14,3 +16,39 @@ def to_single_dash(filename):
         filename = filename[:m.start() + 1] + s2
     return filename
     # selenium-2.0.dev9429.tar.gz
+
+
+class ListExtendingOrderedDict(OrderedDict):
+    """An OrderedDict subclass that aggregates list values for duplicate keys.
+
+    This class extends OrderedDict to provide special handling for list values.
+    When a list value is assigned to an existing key, the new list is extended
+    onto the existing list instead of replacing it.
+
+    In the context of configparser, this allows for accumulating multiple values
+    from different sections or repeated keys, such as in multiline requirements.
+
+    Examples:
+        >>> d = MultiOrderedDict()
+        >>> d['key'] = [1, 2]
+        >>> d['key'] = [3, 4]
+        >>> d['key']
+        [1, 2, 3, 4]
+        >>> d['other'] = 'value'
+        >>> d['other'] = 'new_value'  # Non-list values behave normally
+        >>> d['other']
+        'new_value'
+    """
+
+    def __setitem__(self, key, value):
+        """Sets the value for the given key, extending lists if the key exists.
+
+        Args:
+            key: The dictionary key.
+            value: The value to set. If this is a list and the key already exists,
+                the list will be extended to the existing value instead of replacing it.
+        """
+        if isinstance(value, list) and key in self:
+            self[key].extend(value)
+        else:
+            super().__setitem__(key, value)


### PR DESCRIPTION
This allows the following syntax to pull in both version 0.3.1 as well as 0.4.0:

```ini
[env.windows]
os_name = nt
platform_tag = win_amd64
sys_platform = win32
platform_machine = AMD64
platform_python_implementation = CPython
platform_system = Windows
python_version = 3.12
python_full_version = 3.12.7
implementation_name = cpython

[requirements]
extremeflash = ==0.3.1
extremeflash = ==0.4.0
```

The old syntax, is still supported, though:
```ini

[requirements]
extremeflash = ==0.3.1
               ==0.4.0
```

The new syntax can be disabled with the flag `--enforce-unique-requirements`.