### PR TITLE
ci: install pytest version from pyproject.toml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          pip install pytest
+          python -m pip install .[test]
       - name: Test with pytest
         run: |
           pytest


### PR DESCRIPTION
While working on the CI I noticed that we are always installing the latest pytest version and not the one specified in the pyproject.toml. This fixes it.