### PR TITLE
fix: skipping (take 2)

### DIFF
--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -145,16 +145,19 @@ class Mirrorer:
         if self._processed_pkgs.check(requirement):
             return None
 
-        # Check if requirement is relevant for any environment
-        if not is_requirement_relevant(requirement, self.envs.values()):
-            print(f"\tSkipping {requirement}, not relevant for any environment")
-            self._processed_pkgs.add(requirement)  # Mark as processed
-            return None
-
+        # Display the cause of 'Skipping...'
+        extras = None
         if required_by:
+            extras = required_by.extras
             print(f"[{required_by}]: {requirement}")
         else:
             print(f"{requirement}")
+
+        # Check if requirement is relevant for any environment
+        if not is_requirement_relevant(requirement, self.envs.values(), extras=extras):
+            print("\tSkipping, not relevant for any environment")
+            self._processed_pkgs.add(requirement)  # Mark as processed
+            return None
 
         data: dict | None = None
 
@@ -290,7 +293,7 @@ class Mirrorer:
 
         # Now we only have files that satisfy the requirement, and we need to
         # filter out files that do not match our environments.
-        files = list(filter(lambda file: self._matches_environments(file), files))
+        files = list(filter(self._matches_environments, files))
 
         if len(files) == 0:
             print(f"Skipping {requirement}, no file matches environments")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,6 +2,7 @@
 import argparse
 import hashlib
 import os
+import urllib.error
 
 import packaging.requirements
 import pytest
@@ -282,3 +283,24 @@ class TestFilterFiles:
         )
 
         assert self.extract_versions(filtered_files) == expected_versions
+
+    def test_skipping(self, make_mirrorer):
+        """Test that requirement not skipping."""
+        mirrorer = make_mirrorer(mirror_all_versions=False)
+        required_by = packaging.requirements.Requirement("pyjwt[crypto]==2.10.1")
+        requirement = packaging.requirements.Requirement(
+            "cryptography>=3.4.0; extra == \"crypto\""
+        )
+
+        res = {}
+        try:
+            # if skipping then None
+            res = mirrorer._mirror(  # pylint: disable=protected-access
+                requirement=requirement,
+                required_by=required_by,
+            )
+        except urllib.error.HTTPError:
+            # if not skipping then HTTPError
+            pass
+
+        assert res is not None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -295,7 +295,7 @@ class TestFilterFiles:
         res = {}
         try:
             # if skipping then None
-            res = mirrorer._mirror(  # pylint: disable=protected-access
+            res = mirrorer._mirror(  # noqa: SLF001
                 requirement=requirement,
                 required_by=required_by,
             )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-function-docstring,missing-class-docstring,missing-module-docstring
 import argparse
+import contextlib
 import hashlib
 import os
 import urllib.error
@@ -289,18 +290,16 @@ class TestFilterFiles:
         mirrorer = make_mirrorer(mirror_all_versions=False)
         required_by = packaging.requirements.Requirement("pyjwt[crypto]==2.10.1")
         requirement = packaging.requirements.Requirement(
-            'cryptography>=3.4.0; extra == "crypto"'
+            'cryptography>=3.4.0; extra == "crypto"',
         )
 
         res = {}
-        try:
+        with contextlib.suppress(urllib.error.HTTPError):
             # if skipping then None
             res = mirrorer._mirror(  # noqa: SLF001
                 requirement=requirement,
                 required_by=required_by,
             )
-        except urllib.error.HTTPError:
             # if not skipping then HTTPError
-            pass
 
         assert res is not None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -289,7 +289,7 @@ class TestFilterFiles:
         mirrorer = make_mirrorer(mirror_all_versions=False)
         required_by = packaging.requirements.Requirement("pyjwt[crypto]==2.10.1")
         requirement = packaging.requirements.Requirement(
-            "cryptography>=3.4.0; extra == \"crypto\""
+            'cryptography>=3.4.0; extra == "crypto"'
         )
 
         res = {}


### PR DESCRIPTION
this ini:
```ini
[requirements]
pyjwt = [crypto]==2.10.1
```
results in:
```
[pyjwt[crypto]==2.10.1]: cryptography>=3.4.0; extra == "crypto"
        Skipping, not relevant for any environment
```
so the code needs to know about extras from pyjwt
(take 1: #76)