### PR TITLE
Allow to use Gitlab registry as index + Allow pypi to be used for dependency resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ the mirror instead of pypi.org, which they can't access anyway.
 - Runs under **Python 3.7 and up** (both server and mirrorer).
 - Package index is a **simple directory tree** that can be easily archived, copied,
   rsynced, etc.
+- Alternatively to the directory index, a **GitLab package registry** can be used as a target index.
 - Package index contains a **configuration file** that lists **markers** for
   different client **environments** and a list of **package requirement strings** as per [PEP 508](https://peps.python.org/pep-0508/).
 - Mirrorer automatically and **recursively mirrors dependencies** of all direct

--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -23,6 +23,7 @@ import packaging.version
 
 from morgan import configurator, metadata, server
 from morgan.__about__ import __version__
+from morgan.registry import LocalRegistry, Registry
 from morgan.utils import (
     Cache,
     ListExtendingOrderedDict,
@@ -92,6 +93,7 @@ class Mirrorer:
                     )
 
         self._processed_pkgs = Cache()
+        self.target_registry: Registry = LocalRegistry(self._hash_file, self.index_path)
 
     def mirror(self, requirement_string: str):
         """
@@ -582,7 +584,14 @@ class Mirrorer:
             else next(iter(fileinfo["hashes"]))
         )
 
-        self._download_file(fileinfo, filepath, hashalg)
+        # Check if package already exists in target registry
+        if not self.target_registry.has_package(
+            fileinfo["filename"],
+            requirement.name,
+            hashalg,
+            fileinfo["hashes"][hashalg],
+        ):
+            self._download_file(fileinfo, filepath, hashalg)
 
         md = self._extract_metadata(filepath)
 
@@ -619,8 +628,6 @@ class Mirrorer:
 
         exphash = fileinfo["hashes"][hashalg]
 
-        os.makedirs(os.path.dirname(target), exist_ok=True)
-
         # if target already exists, verify its hash and only download if
         # there's a mismatch
         if os.path.exists(target):
@@ -629,6 +636,7 @@ class Mirrorer:
                 touch_file(target, fileinfo)
                 return True
 
+        os.makedirs(os.path.dirname(target), exist_ok=True)
         print("\t{}...".format(fileinfo["url"]), end=" ")
         with urllib.request.urlopen(  # noqa: S310
             fileinfo["url"],

--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -9,6 +9,7 @@ import os.path
 import re
 import tarfile
 import traceback
+import urllib.error
 import urllib.parse
 import urllib.request
 import zipfile
@@ -94,6 +95,7 @@ class Mirrorer:
 
         self._processed_pkgs = Cache()
         self.target_registry: Registry = self._find_target_registry(args)
+        self.use_pypi_metadata: bool = args.use_pypi_metadata or False
 
     def mirror(self, requirement_string: str):
         """
@@ -593,9 +595,15 @@ class Mirrorer:
         ):
             self._download_file(fileinfo, filepath, hashalg)
 
-        md = self._extract_metadata(filepath)
+        if self.use_pypi_metadata:
+            pkg_metadata = self._extract_metadata_from_pypi(
+                requirement.name,
+                fileinfo["version"],
+            )
+        else:
+            pkg_metadata = self._extract_metadata_from_file(filepath)
 
-        deps = md.dependencies(requirement.extras, self.envs.values())
+        deps = pkg_metadata.dependencies(requirement.extras, self.envs.values())
         if deps is None:
             return None
 
@@ -685,7 +693,7 @@ class Mirrorer:
 
         return truehash.hexdigest()
 
-    def _extract_metadata(
+    def _extract_metadata_from_file(
         self,
         filepath: str,
     ) -> metadata.MetadataParser:
@@ -719,6 +727,30 @@ class Mirrorer:
         archive.close()
 
         return md
+
+    def _extract_metadata_from_pypi(
+        self,
+        package: str,
+        version: packaging.version.Version,
+    ) -> metadata.MetadataParser:
+        """Extract package metadata from PyPI's JSON API.
+
+        Args:
+            package: The name of the package.
+            version: The version of the package.
+
+        Returns:
+            A MetadataParser object filled with metadata from PyPI.
+
+        Raises:
+            urllib.error.HTTPError: If there's an error fetching metadata from PyPI.
+        """
+        pkg_metadata = metadata.PyPIMetadataParser(package, str(version))
+        try:
+            return pkg_metadata.parse_pypi()
+        except urllib.error.HTTPError as e:
+            print(f"\tError fetching metadata from PyPI: {e}")
+            raise
 
 
 def parse_interpreter(inp: str) -> tuple[str, str | None]:
@@ -900,6 +932,18 @@ def main():  # noqa: C901
             "(default: fetch only the wheel for latest compatible Python version)"
         ),
     )
+    parser.add_argument(
+        "--use-pypi-metadata",
+        dest="use_pypi_metadata",
+        action="store_true",
+        help=(
+            "Use PyPI's JSON API to fetch package metadata instead of relying on "
+            "downloaded files in the package-index. "
+            "Enabling this option can result in fewer dependencies being pulled in, "
+            "as some dependencies declared in pyproject.toml (e.g. build-system "
+            "dependencies like poetry) are not considered package dependencies by PyPI."
+        ),
+    )
 
     server.add_arguments(parser)
     configurator.add_arguments(parser)
@@ -922,6 +966,13 @@ def main():  # noqa: C901
     # Validate that target-gitlab-project requires target-url
     if args.target_gitlab_project and not args.target_url:
         parser.error("--target-gitlab-project requires --target-url to be specified")
+
+    if args.target_gitlab_project and not args.use_pypi_metadata:
+        parser.error("--target-gitlab-project requires --use-pypi-metadata")
+
+    # GitLab is the only supported remote target registry so far
+    if args.target_url and not args.target_gitlab_project:
+        parser.error("--target-url requires --target-gitlab-project")
 
     # These commands do not require a configuration file and therefore should
     # be executed prior to sanity checking the configuration

--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -23,7 +23,7 @@ import packaging.version
 
 from morgan import configurator, metadata, server
 from morgan.__about__ import __version__
-from morgan.registry import LocalRegistry, Registry
+from morgan.registry import GitLabRegistry, LocalRegistry, Registry
 from morgan.utils import (
     Cache,
     ListExtendingOrderedDict,
@@ -93,7 +93,7 @@ class Mirrorer:
                     )
 
         self._processed_pkgs = Cache()
-        self.target_registry: Registry = LocalRegistry(self._hash_file, self.index_path)
+        self.target_registry: Registry = self._find_target_registry(args)
 
     def mirror(self, requirement_string: str):
         """
@@ -612,6 +612,20 @@ class Mirrorer:
             }
         return depdict
 
+    def _find_target_registry(self, args: argparse.Namespace) -> Registry:
+        if args.target_url is None:
+            return LocalRegistry(self._hash_file, self.index_path)
+
+        if args.target_gitlab_project:
+            return GitLabRegistry(
+                args.target_url,
+                args.target_gitlab_project,
+                args.target_token,
+            )
+
+        msg = "Target registry is not supported"
+        raise NotImplementedError(msg)
+
     def _download_file(
         self,
         fileinfo: dict,
@@ -822,6 +836,29 @@ def main():  # noqa: C901
         help="Base URL of the Python Package Index",
     )
     parser.add_argument(
+        "-t",
+        "--target-url",
+        dest="target_url",
+        default=None,
+        type=my_url,
+        help='Base URL of the target repository. For example, "https://gitlab.example.com". If not specified, defaults to the local Package Index.',
+    )
+    parser.add_argument(
+        "-T",
+        "--target-auth-bearer",
+        dest="target_token",
+        default=None,
+        type=str,
+        help="Authorization Token for the target repository.",
+    )
+    parser.add_argument(
+        "--target-gitlab-project",
+        dest="target_gitlab_project",
+        default=None,
+        type=str,
+        help="The Gitlab Project that will be used as a target repository.",
+    )
+    parser.add_argument(
         "-c",
         "--config",
         dest="config",
@@ -881,6 +918,10 @@ def main():  # noqa: C901
     )
 
     args = parser.parse_args()
+
+    # Validate that target-gitlab-project requires target-url
+    if args.target_gitlab_project and not args.target_url:
+        parser.error("--target-gitlab-project requires --target-url to be specified")
 
     # These commands do not require a configuration file and therefore should
     # be executed prior to sanity checking the configuration

--- a/morgan/metadata.py
+++ b/morgan/metadata.py
@@ -286,24 +286,25 @@ class MetadataParser:
         requires_dist = data.get_all("Requires-Dist")
         if requires_dist is not None:
             for requirement_str in requires_dist:
-                req = Requirement(requirement_str)
-                extra = None
-                if req.marker is not None:
-                    # ruff: noqa: SLF001
-                    for marker in req.marker._markers:
-                        if (
-                            isinstance(marker[0], MarkerVariable)
-                            and marker[0].value == "extra"
-                        ):
-                            extra = marker[2].value
-                            break
+                self._parse_requires_dist(requirement_str)
 
-                if extra:
-                    if extra not in self.optional_dependencies:
-                        self.optional_dependencies[extra] = set()
-                    self.optional_dependencies[extra].add(req)
-                else:
-                    self.core_dependencies.add(req)
+    def _parse_requires_dist(self, requirement_str: str):
+        req = Requirement(requirement_str)
+        extra = None
+        if req.marker is not None:
+            # ruff: noqa: SLF001
+            for marker in req.marker._markers:
+                if isinstance(marker[0], MarkerVariable) and marker[0].value == "extra":
+                    extra = marker[2].value
+                    break
+
+        if not extra:
+            self.core_dependencies.add(req)
+            return
+
+        if extra not in self.optional_dependencies:
+            self.optional_dependencies[extra] = set()
+        self.optional_dependencies[extra].add(req)
 
     def _parse_metadata_11(self, data):
         requires = data.get_all("Requires")

--- a/morgan/metadata.py
+++ b/morgan/metadata.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import email.parser
+import gzip
+import json
 import re
+import urllib.error
+import urllib.request
 from typing import IO, Any, Callable, Iterable
 
 import tomli
@@ -344,3 +348,83 @@ class MetadataParser:
     def _add_build_requirements(self, reqs):
         msg = "Setuptools build requirements not supported"
         raise NotImplementedError(msg)
+
+
+class PyPIMetadataParser(MetadataParser):
+    """Metadata Parser for PyPI's JSON API.
+
+    This class extends MetadataParser to parse metadata from PyPI's JSON API
+    without needing an opener/filename for local files.
+    """
+
+    def __init__(self, package_name: str, version_str: str):
+        super().__init__(f"pypi:{package_name}-{version_str}")
+        self.package_name = package_name
+        self.version_str = version_str
+
+    def parse(
+        self,
+        opener: Callable[[str], IO[bytes] | None],
+        filename: str,
+    ) -> None:
+        msg = "Use parse_pypi() instead of parse() for PyPIMetadataParser"
+        raise NotImplementedError(msg)
+
+    def parse_pypi(self) -> MetadataParser:
+        """Extract package metadata from PyPI's JSON API.
+
+        Returns:
+            A MetadataParser object populated with metadata from PyPI.
+
+        Raises:
+            urllib.error.HTTPError: If the API request fails.
+            ValueError: If the API response is invalid or cannot be parsed.
+        """
+
+        url = f"https://pypi.org/pypi/{self.package_name}/{self.version_str}/json"
+
+        request = urllib.request.Request(  # noqa: S310
+            url,
+            headers={
+                "Accept": "application/json",
+                "Accept-Encoding": "gzip",
+            },
+        )
+
+        with urllib.request.urlopen(request) as response:  # noqa: S310
+            # Check if response is gzip-encoded
+            if response.headers.get("Content-Encoding") == "gzip":
+                with gzip.GzipFile(fileobj=response) as gzip_response:
+                    data = json.load(gzip_response)
+            else:
+                data = json.load(response)
+
+        received_version = data["info"].get("version")
+        # PyPI returns the version as uploaded (e.g. "0.6c1"), which may differ
+        # from the PEP 440 normalized form in version_str (e.g. "0.6rc1")
+        if received_version is None or Version(received_version) != Version(
+            self.version_str,
+        ):
+            msg = f"Version mismatch: requested {self.version_str}, got {received_version}"
+            raise ValueError(msg)
+
+        # Create and populate the metadata parser
+        self.name = canonicalize_name(data["info"]["name"])
+        self.version = Version(received_version)
+
+        # Extract Python requirement
+        requires_python = data["info"].get("requires_python")
+        if requires_python:
+            self.python_requirement = SpecifierSet(requires_python)
+
+        provides_extra = data["info"].get("provides_extra")
+        if provides_extra:
+            self.extras_provided |= set(provides_extra)
+
+        # Parse dependencies
+        requires_dist = data["info"].get("requires_dist")
+        if requires_dist is not None:
+            for requirement_str in requires_dist:
+                self._parse_requires_dist(requirement_str)
+
+        return self

--- a/morgan/registry.py
+++ b/morgan/registry.py
@@ -1,0 +1,75 @@
+"""Package registry functionality for target package registries.
+
+This module provides abstractions for working with different target package registries,
+for mirroring.
+"""
+
+from __future__ import annotations
+
+import os
+from abc import ABC, abstractmethod
+from typing import Callable
+
+
+class Registry(ABC):
+    """Abstract base class for package registries."""
+
+    @abstractmethod
+    def has_package(
+        self,
+        file_name: str,
+        package_name: str,
+        hash_alg: str,
+        expected_hash: str | None = None,
+    ) -> bool:
+        """Check if a package file exists in the registry.
+
+        Args:
+            file_name: Name of the distribution file (e.g. "pkg-1.0.0.tar.gz")
+            package_name: Name of the package the file belongs to
+            hash_alg: Hash algorithm to use for verification
+            expected_hash: Expected hash of the file; if None, existence alone
+                is sufficient
+
+        Returns:
+            True if the file exists (and matches expected_hash when given),
+            False otherwise
+
+        """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Return the name of this registry."""
+
+
+class LocalRegistry(Registry):
+    """Registry implementation that checks the local file system."""
+
+    def __init__(self, hash_file_func: Callable, index_path: str):
+        self.hash_file_func = hash_file_func
+        self.index_path = index_path
+
+    @property
+    def name(self) -> str:
+        return "Local"
+
+    def has_package(
+        self,
+        file_name: str,
+        package_name: str,
+        hash_alg: str,
+        expected_hash: str | None = None,
+    ) -> bool:
+        # if target already exists, verify its hash and only download if
+        # there's a mismatch
+        target = os.path.join(self.index_path, package_name, file_name)
+        if not os.path.exists(target):
+            return False
+
+        # nothing else to do if there is no expected hash
+        if not expected_hash:
+            return True
+
+        truehash = self.hash_file_func(target, hash_alg)
+        return truehash == expected_hash

--- a/morgan/registry.py
+++ b/morgan/registry.py
@@ -6,9 +6,17 @@ for mirroring.
 
 from __future__ import annotations
 
+import json
+import logging
 import os
+import urllib.error
+import urllib.request
 from abc import ABC, abstractmethod
 from typing import Callable
+
+from packaging.utils import canonicalize_name
+
+logger = logging.getLogger(__name__)
 
 
 class Registry(ABC):
@@ -73,3 +81,206 @@ class LocalRegistry(Registry):
 
         truehash = self.hash_file_func(target, hash_alg)
         return truehash == expected_hash
+
+
+class GitLabRegistry(Registry):
+    """Registry implementation that checks a GitLab package registry."""
+
+    def __init__(self, registry_url: str, project: str, token: str | None = None):
+        self.registry_url = registry_url
+        self.project = project
+        self.token = token
+        self.headers = {}
+        if self.token:
+            self.headers["Authorization"] = f"Bearer {self.token}"
+        self._packages_cache: list | None = None
+        self._package_files_cache: dict[int, list] = {}
+
+    @property
+    def name(self) -> str:
+        return f"GitLab ({self.registry_url})"
+
+    @staticmethod
+    def _parse_link_header(link_header: str) -> dict[str, str]:
+        """Parse the Link header according to RFC2068 section 19.6.2.4.
+
+        Args:
+            link_header: The Link header string to parse.
+
+        Returns:
+            A dictionary mapping relationship types to URLs.
+        """
+        if not link_header:
+            return {}
+
+        links: dict = {}
+
+        # Process each link section (separated by commas)
+        for section in link_header.split(","):
+            section = section.strip()  # noqa: PLW2901
+            if not section:
+                continue
+
+            GitLabRegistry._process_link_section(section, links)
+
+        return links
+
+    @staticmethod
+    def _process_link_section(section: str, links: dict[str, str]) -> None:
+        """Process a single link section and update the links dictionary."""
+        parts = section.split(";")
+        if not parts:
+            logger.error(
+                "Error: Invalid Link header section: %s. Ignoring section.",
+                section,
+            )
+            return
+
+        url_part = parts[0].strip()
+        if not (url_part.startswith("<") and url_part.endswith(">")):
+            logger.error(
+                "Error: Unexpected Link header format: %s. Ignoring section.",
+                url_part,
+            )
+            return
+
+        url = url_part[1:-1]  # Remove <,> brackets
+
+        # Process the parameters
+        for param in parts[1:]:
+            param = param.strip()  # noqa: PLW2901
+            if "=" not in param:
+                logger.error(
+                    "Error: Unable to find '=' in link header: %s. Ignoring parameter.",
+                    param,
+                )
+                continue
+
+            name, value = param.split("=", 1)
+            normalized_name = name.strip().lower()
+            value = value.strip()
+
+            if normalized_name == "rel":
+                GitLabRegistry._add_rel_to_links(value, url, links)
+
+    @staticmethod
+    def _add_rel_to_links(value: str, url: str, links: dict[str, str]) -> None:
+        """Add relation types to the links dictionary."""
+        # If value is quoted, it may contain multiple space-separated relation types
+        if value.startswith('"') and value.endswith('"'):
+            value = value[1:-1]  # Remove quotes
+            # Handle multiple relation types in a quoted string
+            for rel_type in value.split():
+                links[rel_type.lower()] = url
+        else:
+            # Otherwise, it's a single relation type
+            links[value.lower()] = url
+
+    def _fetch_paginated_api(self, api_url: str) -> list:
+        """Fetch paginated results from GitLab API.
+
+        Args:
+            api_url: The API URL to fetch from, including any query parameters
+
+        Returns:
+            List of all items from all pages
+
+        Raises:
+            RuntimeError: If the API request fails or returns unexpected format
+
+        """
+        results = []
+        current_url: str | None = api_url + "?per_page=100"
+
+        while current_url:
+            # avoid potential CVE, see https://docs.astral.sh/ruff/rules/suspicious-url-open-usage/
+            if not current_url.startswith(("http:", "https:")):
+                msg = "URL must start with 'http:' or 'https:'"
+                raise ValueError(msg)
+
+            try:
+                request = urllib.request.Request(current_url, headers=self.headers)  # noqa: S310
+                with urllib.request.urlopen(request) as response:  # noqa: S310
+                    page_data = json.load(response)
+
+                    # Check response format
+                    if not isinstance(page_data, list):
+                        msg = f"Unexpected response format from {self.name}, expected a list: {page_data}"
+                        raise TypeError(msg)
+
+                    results.extend(page_data)
+
+                    # Check for pagination in Link header
+                    link_header = response.headers.get("Link")
+                    if not link_header:
+                        break
+
+                    links = self._parse_link_header(link_header)
+                    current_url = links.get("next")
+
+            except (urllib.error.URLError, json.JSONDecodeError) as e:
+                msg = f"Failed to read data from {current_url}"
+                raise RuntimeError(msg) from e
+
+        return results
+
+    def _fetch_packages_list(self) -> list:
+        """Fetch package files from the API and cache the result."""
+        if self._packages_cache is not None:
+            return self._packages_cache
+
+        api_url = f"{self.registry_url}/api/v4/projects/{self.project}/packages"
+        self._packages_cache = self._fetch_paginated_api(api_url)
+        return self._packages_cache
+
+    def _fetch_package_files(self, package_id: int) -> list:
+        """Fetch package files from the API and cache the result."""
+        if (
+            package_id in self._package_files_cache
+            and self._package_files_cache[package_id] is not None
+        ):
+            return self._package_files_cache[package_id]
+
+        api_url = f"{self.registry_url}/api/v4/projects/{self.project}/packages/{package_id}/package_files"
+        self._package_files_cache[package_id] = self._fetch_paginated_api(api_url)
+        return self._package_files_cache[package_id]
+
+    def has_package(
+        self,
+        file_name: str,
+        package_name: str,
+        hash_alg: str,
+        expected_hash: str | None = None,
+    ) -> bool:
+        packages = self._fetch_packages_list()
+        package_name = canonicalize_name(package_name)
+
+        for package in packages:
+            if canonicalize_name(package.get("name")) != package_name:
+                continue
+
+            for file_info in self._fetch_package_files(package.get("id")):
+                # canonicalize_name() is only valid for package names; applying
+                # it here would collapse distinct filenames
+                if file_info.get("file_name") != file_name:
+                    continue
+
+                if file_info.get(f"file_{hash_alg}") == expected_hash:
+                    return True
+                # missing hash field (GitLab only stores md5/sha1/sha256) or a
+                # genuine mismatch: treat the file as absent so the caller
+                # re-downloads it, mirroring LocalRegistry semantics
+                logger.warning(
+                    "%s hash of %s in %s is missing or does not match the "
+                    "expected value, treating file as missing",
+                    hash_alg,
+                    file_name,
+                    self.name,
+                )
+
+        return False
+
+    def clear_cache(self):
+        """Clear the cached package files. Useful for testing or if registry content changes."""
+        self._packages_cache = None
+        self._package_files_cache = {}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -105,6 +105,7 @@ class TestMirrorer:
             mirror_all_versions=False,
             package_type_regex="(whl|zip|tar.gz)",
             mirror_all_wheels=False,
+            target_url=None,
         )
 
         mirrorer = Mirrorer(args)
@@ -125,6 +126,7 @@ class TestMirrorer:
             mirror_all_versions=False,
             package_type_regex="(whl|zip|tar.gz)",
             mirror_all_wheels=False,
+            target_url=None,
         )
         mirrorer = Mirrorer(args)
 
@@ -151,6 +153,7 @@ class TestMirrorer:
             mirror_all_versions=False,
             package_type_regex="(whl|zip|tar.gz)",
             mirror_all_wheels=False,
+            target_url=None,
         )
         mirrorer = Mirrorer(args)
 
@@ -201,6 +204,7 @@ class TestFilterFiles:
                 mirror_all_versions=mirror_all_versions,
                 package_type_regex=r"(whl|zip|tar\.gz)",
                 mirror_all_wheels=mirror_all_wheels,
+                target_url=None,
             )
             return Mirrorer(args)
 
@@ -602,6 +606,7 @@ class TestMirrorDependencyErrors:
             mirror_all_versions=False,
             package_type_regex=r"(whl|zip|tar\.gz)",
             mirror_all_wheels=False,
+            target_url=None,
         )
         return Mirrorer(args)
 
@@ -702,6 +707,7 @@ class TestDownloadFile:
             mirror_all_versions=False,
             package_type_regex="(whl|zip|tar.gz)",
             mirror_all_wheels=False,
+            target_url=None,
         )
         return Mirrorer(args)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -106,6 +106,7 @@ class TestMirrorer:
             package_type_regex="(whl|zip|tar.gz)",
             mirror_all_wheels=False,
             target_url=None,
+            use_pypi_metadata=False,
         )
 
         mirrorer = Mirrorer(args)
@@ -127,6 +128,7 @@ class TestMirrorer:
             package_type_regex="(whl|zip|tar.gz)",
             mirror_all_wheels=False,
             target_url=None,
+            use_pypi_metadata=False,
         )
         mirrorer = Mirrorer(args)
 
@@ -154,6 +156,7 @@ class TestMirrorer:
             package_type_regex="(whl|zip|tar.gz)",
             mirror_all_wheels=False,
             target_url=None,
+            use_pypi_metadata=False,
         )
         mirrorer = Mirrorer(args)
 
@@ -205,6 +208,7 @@ class TestFilterFiles:
                 package_type_regex=r"(whl|zip|tar\.gz)",
                 mirror_all_wheels=mirror_all_wheels,
                 target_url=None,
+                use_pypi_metadata=False,
             )
             return Mirrorer(args)
 
@@ -607,6 +611,7 @@ class TestMirrorDependencyErrors:
             package_type_regex=r"(whl|zip|tar\.gz)",
             mirror_all_wheels=False,
             target_url=None,
+            use_pypi_metadata=False,
         )
         return Mirrorer(args)
 
@@ -708,6 +713,7 @@ class TestDownloadFile:
             package_type_regex="(whl|zip|tar.gz)",
             mirror_all_wheels=False,
             target_url=None,
+            use_pypi_metadata=False,
         )
         return Mirrorer(args)
 

--- a/tests/test_init_wheelscore.py
+++ b/tests/test_init_wheelscore.py
@@ -39,6 +39,7 @@ class TestCalculateScoresForWheel:
             mirror_all_versions=False,
             package_type_regex=r"(whl|zip|tar\.gz)",
             mirror_all_wheels=True,
+            target_url=None,
         )
         return Mirrorer(args)
 

--- a/tests/test_init_wheelscore.py
+++ b/tests/test_init_wheelscore.py
@@ -40,6 +40,7 @@ class TestCalculateScoresForWheel:
             package_type_regex=r"(whl|zip|tar\.gz)",
             mirror_all_wheels=True,
             target_url=None,
+            use_pypi_metadata=False,
         )
         return Mirrorer(args)
 

--- a/tests/test_metadata_parser.py
+++ b/tests/test_metadata_parser.py
@@ -187,3 +187,46 @@ pytest>=6.0.0
 
         deps = parser.dependencies(extras, [{"python_version": python_version}])
         assert len(deps) == expected_count
+
+
+class TestMetadataParserRequiresDist:
+    @pytest.fixture
+    def parser(self):
+        """Basic parser instance for testing"""
+        return MetadataParser("example-package-1.0.0.tar.gz")
+
+    def test_parse_requires_dist_simple(self, parser):
+        """Test parsing a simple requirement without extras or markers"""
+        # pylint: disable=W0212
+        parser._parse_requires_dist("requests>=2.0.0")  # noqa: SLF001
+
+        assert len(parser.core_dependencies) == 1
+        req = parser.core_dependencies.pop()
+        assert req.name == "requests"
+        assert str(req.specifier) == ">=2.0.0"
+        assert not req.extras
+        assert req.marker is None
+
+    def test_parse_requires_dist_with_env_marker(self, parser):
+        """Test parsing a requirement with environment marker (non-extra)"""
+        # pylint: disable=W0212
+        parser._parse_requires_dist("numpy>=1.20.0; python_version >= '3.8'")  # noqa: SLF001
+
+        assert len(parser.core_dependencies) == 1
+        req = parser.core_dependencies.pop()
+        assert req.name == "numpy"
+        assert req.marker is not None
+
+    def test_parse_requires_dist_with_extra(self, parser):
+        """Test parsing a requirement with an extra marker"""
+        # pylint: disable=W0212
+        parser._parse_requires_dist('flask>=2.0.0; extra == "web"')  # noqa: SLF001
+
+        assert len(parser.core_dependencies) == 0
+        assert "web" in parser.optional_dependencies
+        assert len(parser.optional_dependencies["web"]) == 1
+
+        req = parser.optional_dependencies["web"].pop()
+        assert req.name == "flask"
+        assert str(req.specifier) == ">=2.0.0"
+        assert req.marker is not None

--- a/tests/test_pypi_metadata_parser.py
+++ b/tests/test_pypi_metadata_parser.py
@@ -1,0 +1,322 @@
+import gzip
+import io
+import json
+import urllib.error
+from http.client import HTTPMessage
+from typing import BinaryIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+from packaging.version import Version
+
+from morgan import Mirrorer
+from morgan.metadata import PyPIMetadataParser
+
+
+class TestPyPIMetadataParser:
+    @pytest.fixture
+    def basic_package_data(self):
+        """Basic package data from PyPI JSON API"""
+        return {
+            "info": {
+                "name": "example-package",
+                "version": "1.0.0",
+                "requires_python": ">=3.7",
+                "requires_dist": ["requests>=2.0.0"],
+            },
+        }
+
+    @pytest.fixture
+    def realistic_package_data(self):
+        """Complex package data with extras and conditional dependencies"""
+        return {
+            "info": {
+                "author": "Kenneth Reitz",
+                "author_email": "me@kennethreitz.org",
+                "bugtrack_url": None,
+                "classifiers": [
+                    "Development Status :: 5 - Production/Stable",
+                    "Environment :: Web Environment",
+                    "Intended Audience :: Developers",
+                    "License :: OSI Approved :: Apache Software License",
+                    "Natural Language :: English",
+                    "Operating System :: OS Independent",
+                    "Programming Language :: Python",
+                    "Programming Language :: Python :: 3",
+                    "Programming Language :: Python :: 3 :: Only",
+                    "Programming Language :: Python :: 3.10",
+                    "Programming Language :: Python :: 3.11",
+                    "Programming Language :: Python :: 3.12",
+                    "Programming Language :: Python :: 3.13",
+                    "Programming Language :: Python :: 3.14",
+                    "Programming Language :: Python :: 3.9",
+                    "Programming Language :: Python :: Implementation :: CPython",
+                    "Programming Language :: Python :: Implementation :: PyPy",
+                    "Topic :: Internet :: WWW/HTTP",
+                    "Topic :: Software Development :: Libraries",
+                ],
+                "description": "# Requests",
+                "description_content_type": "text/markdown",
+                "docs_url": None,
+                "download_url": None,
+                "downloads": {"last_day": -1, "last_month": -1, "last_week": -1},
+                "dynamic": [
+                    "Author",
+                    "Author-Email",
+                    "Classifier",
+                    "Description",
+                    "Description-Content-Type",
+                    "Home-Page",
+                    "License",
+                    "License-File",
+                    "Project-Url",
+                    "Provides-Extra",
+                    "Requires-Dist",
+                    "Requires-Python",
+                    "Summary",
+                ],
+                "home_page": "https://requests.readthedocs.io",
+                "keywords": None,
+                "license": "Apache-2.0",
+                "license_expression": None,
+                "license_files": ["LICENSE"],
+                "maintainer": None,
+                "maintainer_email": None,
+                "name": "requests",
+                "package_url": "https://pypi.org/project/requests/",
+                "platform": None,
+                "project_url": "https://pypi.org/project/requests/",
+                "project_urls": {
+                    "Documentation": "https://requests.readthedocs.io",
+                    "Homepage": "https://requests.readthedocs.io",
+                    "Source": "https://github.com/psf/requests",
+                },
+                "provides_extra": ["security", "socks", "use-chardet-on-py3"],
+                "release_url": "https://pypi.org/project/requests/2.32.5/",
+                "requires_dist": [
+                    "charset_normalizer<4,>=2",
+                    "idna<4,>=2.5",
+                    "urllib3<3,>=1.21.1",
+                    "certifi>=2017.4.17",
+                    'PySocks!=1.5.7,>=1.5.6; extra == "socks"',
+                    'chardet<6,>=3.0.2; extra == "use-chardet-on-py3"',
+                ],
+                "requires_python": ">=3.9",
+                "summary": "Python HTTP for Humans.",
+                "version": "2.32.5",
+                "yanked": False,
+                "yanked_reason": None,
+            },
+        }
+
+    def setup_mock_response(self, mock_urlopen, data, gzip_encoded=False):
+        """Helper to set up a mock HTTP response"""
+        mock_response = MagicMock()
+        mock_response.headers = {}
+
+        if gzip_encoded:
+            mock_response.headers["Content-Encoding"] = "gzip"
+            # Create gzipped content
+            json_bytes = json.dumps(data).encode("utf-8")
+            gzipped = io.BytesIO()
+            with gzip.GzipFile(fileobj=gzipped, mode="wb") as f:
+                f.write(json_bytes)
+            gzipped.seek(0)
+            # Make the mock response behave like a file-like object for gzip.GzipFile
+            mock_response.read = gzipped.read
+            mock_response.read1 = gzipped.read1
+        else:
+            mock_response.read.return_value = json.dumps(data).encode("utf-8")
+
+        # Mock the context manager behavior
+        mock_response.__enter__.return_value = mock_response
+        mock_urlopen.return_value = mock_response
+
+    def test_basic_parsing(self, basic_package_data):
+        """Test basic metadata parsing from PyPI"""
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            self.setup_mock_response(mock_urlopen, basic_package_data)
+
+            parser = PyPIMetadataParser("example-package", "1.0.0")
+            result = parser.parse_pypi()
+
+            assert result.name == "example-package"
+            assert result.version == Version("1.0.0")
+            assert str(result.python_requirement) == ">=3.7"
+            assert len(result.core_dependencies) == 1
+            assert next(iter(result.core_dependencies)).name == "requests"
+
+            # Verify the URL was correctly constructed
+            mock_urlopen.assert_called_once()
+            request = mock_urlopen.call_args[0][0]
+            assert (
+                request.full_url == "https://pypi.org/pypi/example-package/1.0.0/json"
+            )
+
+    def test_complex_parsing_with_extras(self, realistic_package_data):
+        """Test parsing with extras and conditional dependencies"""
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            self.setup_mock_response(mock_urlopen, realistic_package_data)
+
+            parser = PyPIMetadataParser("requests", "2.32.5")
+            result = parser.parse_pypi()
+
+            assert result.name == "requests"
+            assert result.version == Version("2.32.5")
+            assert str(result.python_requirement) == ">=3.9"
+            assert result.extras_provided == {"security", "socks", "use-chardet-on-py3"}
+
+            # Check core dependencies
+            assert len(result.core_dependencies) == 4
+            core_dep_names = {dep.name for dep in result.core_dependencies}
+            assert "charset_normalizer" in core_dep_names
+            assert "idna" in core_dep_names
+            assert "urllib3" in core_dep_names
+            assert "certifi" in core_dep_names
+
+            # Check optional dependencies
+            assert set(result.optional_dependencies.keys()) == {
+                "socks",
+                "use-chardet-on-py3",
+            }
+            assert len(result.optional_dependencies["socks"]) == 1
+            assert next(iter(result.optional_dependencies["socks"])).name == "PySocks"
+            assert len(result.optional_dependencies["use-chardet-on-py3"]) == 1
+            assert (
+                next(iter(result.optional_dependencies["use-chardet-on-py3"])).name
+                == "chardet"
+            )
+
+    def test_gzip_encoded_response(self, basic_package_data):
+        """Test handling of gzip-encoded responses"""
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            self.setup_mock_response(
+                mock_urlopen,
+                basic_package_data,
+                gzip_encoded=True,
+            )
+
+            parser = PyPIMetadataParser("example-package", "1.0.0")
+            result = parser.parse_pypi()
+
+            assert result.name == "example-package"
+            assert result.version == Version("1.0.0")
+
+            # Verify correct headers were sent
+            request = mock_urlopen.call_args[0][0]
+            headers_lower = {
+                key.lower(): value for key, value in request.headers.items()
+            }  # RFC 2616 specifies headers to be case-insensitive
+            assert headers_lower["accept-encoding"] == "gzip"
+
+    def test_http_error_handling(self):
+        """Test handling of HTTP errors"""
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.side_effect = urllib.error.HTTPError(
+                "https://pypi.org/pypi/nonexistent/1.0.0/json",
+                404,
+                "Not Found",
+                HTTPMessage(),
+                None,
+            )
+
+            parser = PyPIMetadataParser("nonexistent", "1.0.0")
+            with pytest.raises(urllib.error.HTTPError):
+                parser.parse_pypi()
+
+    def test_version_mismatch_handling(self):
+        """Test handling of version mismatch between requested and received"""
+        data = {
+            "info": {
+                "name": "example-package",
+                "version": "1.0.1",  # Different from requested version
+            },
+        }
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            self.setup_mock_response(mock_urlopen, data)
+
+            parser = PyPIMetadataParser("example-package", "1.0.0")
+            with pytest.raises(ValueError, match="Version mismatch"):
+                parser.parse_pypi()
+
+    def test_version_equivalent_non_normalized(self):
+        """Test that a PEP 440 equivalent but non-normalized version is accepted"""
+        data = {
+            "info": {
+                "name": "example-package",
+                "version": "0.6c1",  # PyPI-stored form of the normalized "0.6rc1"
+            },
+        }
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            self.setup_mock_response(mock_urlopen, data)
+
+            parser = PyPIMetadataParser("example-package", "0.6rc1")
+            result = parser.parse_pypi()
+
+            assert result.version == Version("0.6rc1")
+
+    def test_parse_overridden(self):
+        """Test that parse method is properly overridden to raise NotImplementedError"""
+        parser = PyPIMetadataParser("example-package", "1.0.0")
+        with pytest.raises(NotImplementedError):
+            parser.parse(lambda x: MagicMock(spec=BinaryIO), "filename")
+
+
+class TestMirrorerPyPIMetadata:
+    @pytest.fixture
+    def mirrorer_args(self):
+        """Create mock args for Mirrorer initialization"""
+        args = MagicMock()
+        args.index_path = "/dummy/path"
+        args.index_url = "https://pypi.org/simple/"
+        args.config = "morgan.ini"
+        args.target_url = None
+        args.use_pypi_metadata = True
+        return args
+
+    @pytest.fixture
+    def mirrorer(self, mirrorer_args):
+        """Create a Mirrorer instance with mocked dependencies"""
+        with patch("morgan.Mirrorer._find_target_registry"), patch(
+            "configparser.ConfigParser.read",
+        ), patch("configparser.ConfigParser.__getitem__", return_value={}):
+            mirrorer = Mirrorer(mirrorer_args)
+            # pylint: disable=W0212
+            mirrorer._hash_file = MagicMock(return_value="hash123")  # type: ignore[method-assign] # noqa: SLF001
+            return mirrorer
+
+    def test_extract_metadata_from_pypi(self, mirrorer):
+        """Test _extract_metadata_from_pypi method"""
+        package = "example-package"
+        version = Version("1.0.0")
+
+        with patch("morgan.metadata.PyPIMetadataParser.parse_pypi") as mock_parse_pypi:
+            mock_parse_pypi.return_value = MagicMock()
+
+            # pylint: disable=W0212
+            mirrorer._extract_metadata_from_pypi(package, version)  # noqa: SLF001
+
+            # Verify PyPIMetadataParser was initialized with correct parameters
+            mock_parse_pypi.assert_called_once()
+
+    def test_extract_metadata_from_pypi_http_error(self, mirrorer):
+        """Test error handling in _extract_metadata_from_pypi"""
+        package = "example-package"
+        version = Version("1.0.0")
+
+        with patch(
+            "morgan.metadata.PyPIMetadataParser.parse_pypi",
+        ) as mock_parse_pypi:
+            mock_parse_pypi.side_effect = urllib.error.HTTPError(
+                "url",
+                404,
+                "Not Found",
+                HTTPMessage(),
+                None,
+            )
+
+            with pytest.raises(urllib.error.HTTPError):
+                # pylint: disable=W0212
+                mirrorer._extract_metadata_from_pypi(package, version)  # noqa: SLF001

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,188 @@
+import hashlib
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from morgan.registry import LocalRegistry, Registry
+
+
+class TestRegistry:
+    """Tests for the abstract Registry base class."""
+
+    def test_registry_is_abstract(self):
+        """Test that Registry cannot be instantiated directly."""
+        with pytest.raises(TypeError):
+            Registry()  # type: ignore[abstract]
+
+    def test_registry_requires_has_package_implementation(self):
+        """Test that subclasses must implement has_package method."""
+
+        class IncompleteRegistry(Registry):
+            @property
+            def name(self) -> str:
+                return "Incomplete"
+
+        with pytest.raises(TypeError):
+            IncompleteRegistry()  # type: ignore[abstract]
+
+    def test_registry_requires_name_property(self):
+        """Test that subclasses must implement name property."""
+
+        class IncompleteRegistry(Registry):
+            def has_package(
+                self,
+                file_name,
+                package_name,
+                hash_alg,
+                expected_hash=None,
+            ):
+                return False
+
+        with pytest.raises(TypeError):
+            IncompleteRegistry()  # type: ignore[abstract]
+
+
+class TestLocalRegistry:
+    """Tests for the LocalRegistry implementation."""
+
+    @pytest.fixture
+    def mock_file_hashing(self) -> Callable[[Path, str], str]:
+        """Create a mock hash function."""
+
+        def hash_func(file_path: Path, hash_alg: str) -> str:
+            # Simple mock that returns a predictable hash based on file content
+            with open(file_path, "rb") as f:
+                content = f.read()
+                if hash_alg == "sha256":
+                    return hashlib.sha256(content).hexdigest()
+                if hash_alg == "md5":
+                    return hashlib.md5(content).hexdigest()  # noqa: S324
+                if hash_alg is None:
+                    return "no_hash"
+
+                msg = f"Unsupported hash algorithm: {hash_alg}"
+                raise ValueError(msg)
+
+        return hash_func
+
+    @pytest.fixture
+    def local_registry(self, tmp_path: Path, mock_file_hashing) -> LocalRegistry:
+        """Create a LocalRegistry instance for testing."""
+        return LocalRegistry(mock_file_hashing, str(tmp_path))
+
+    @pytest.fixture
+    def create_package_file(self, tmp_path: Path):
+        """Factory fixture to create package files with specified parameters."""
+
+        def _create_package_file(
+            package_name: str,
+            file_name: str,
+            content: str = "test content",
+        ) -> Path:
+            """Create a package directory and file.
+
+            Args:
+                package_name: Name of the package directory
+                file_name: Name of the package file
+                content: Content to write to the file
+
+            Returns:
+                Path to the created file
+
+            """
+            package_dir = tmp_path / package_name
+            package_dir.mkdir(parents=True, exist_ok=True)
+            test_file = package_dir / file_name
+            test_file.write_text(content)
+            return test_file
+
+        return _create_package_file
+
+    def test_local_registry_initialization(self, mock_file_hashing, tmp_path: Path):
+        """Test that LocalRegistry initializes correctly."""
+        registry = LocalRegistry(mock_file_hashing, str(tmp_path))
+        assert registry.hash_file_func == mock_file_hashing
+        assert registry.index_path == str(tmp_path)
+
+    def test_local_registry_name(self, local_registry: LocalRegistry):
+        """Test that LocalRegistry returns correct name."""
+        assert local_registry.name == "Local"
+
+    def test_has_package_file_does_not_exist(self, local_registry: LocalRegistry):
+        """Test has_package returns False when file doesn't exist."""
+        result = local_registry.has_package(
+            file_name="nonexistent-1.0.0.tar.gz",
+            package_name="nonexistent",
+            hash_alg="sha256",
+            expected_hash="abc123",
+        )
+        assert result is False
+
+    def test_has_package_file_exists_no_hash(self, tmp_path: Path, create_package_file):
+        """Test has_package returns True when file exists and no hash is provided."""
+
+        # Create registry with a real hash function for this test
+        def simple_hash(_: Path, __: str) -> str:
+            return "not_called"
+
+        registry = LocalRegistry(simple_hash, str(tmp_path))
+
+        # Create a test package directory and file
+        create_package_file("test-package", "test-package-1.0.0.tar.gz")
+
+        result = registry.has_package(
+            file_name="test-package-1.0.0.tar.gz",
+            package_name="test-package",
+            hash_alg="sha256",
+            expected_hash=None,
+        )
+        assert result is True
+
+    @pytest.mark.parametrize(
+        ("package_name", "file_name", "content", "hash_alg"),
+        [
+            ("my-test-package", "my-test-package-2.3.4.whl", "wheel content", "sha256"),
+            ("empty-package", "empty-package-0.0.1.tar.gz", "", "sha256"),
+            ("hash-test", "hash-test-1.0.0.tar.gz", "md5 content", "md5"),
+            ("ignore-hash-test", "ignore-hash-test-1.0.tar.gz", "some content", None),
+        ],
+    )
+    def test_has_package_with_matching_hash(  # noqa: PLR0913
+        self,
+        local_registry: LocalRegistry,
+        mock_file_hashing,
+        create_package_file,
+        package_name: str,
+        file_name: str,
+        content: str,
+        hash_alg: str,
+    ):
+        """Test has_package returns True with various files and matching hashes."""
+        test_file = create_package_file(package_name, file_name, content)
+        expected_hash = mock_file_hashing(test_file, hash_alg)
+
+        result = local_registry.has_package(
+            file_name=file_name,
+            package_name=package_name,
+            hash_alg=hash_alg,
+            expected_hash=expected_hash,
+        )
+        assert result is True
+
+    def test_has_package_file_exists_with_mismatched_hash(
+        self,
+        local_registry: LocalRegistry,
+        create_package_file,
+    ):
+        """Test has_package returns False when file exists with mismatched hash."""
+        # Create a test package directory and file
+        create_package_file("test-package", "test-package-1.0.0.tar.gz")
+
+        result = local_registry.has_package(
+            file_name="test-package-1.0.0.tar.gz",
+            package_name="test-package",
+            hash_alg="sha256",
+            expected_hash="wrong_hash_value",
+        )
+        assert result is False

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,10 +1,13 @@
 import hashlib
+import json
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Callable
 
 import pytest
 
-from morgan.registry import LocalRegistry, Registry
+from morgan.registry import GitLabRegistry, LocalRegistry, Registry
 
 
 class TestRegistry:
@@ -186,3 +189,302 @@ class TestLocalRegistry:
             expected_hash="wrong_hash_value",
         )
         assert result is False
+
+
+class TestGitLabRegistry:
+    """Tests for the GitLabRegistry implementation."""
+
+    @pytest.fixture
+    def gitlab_registry(self):
+        """Create a GitLabRegistry instance for testing."""
+        return GitLabRegistry(
+            registry_url="https://gitlab.example.com",
+            project="test-project",
+            token="test-token",  # noqa: S106
+        )
+
+    def test_gitlab_registry_initialization_with_token(self):
+        """Test that GitLabRegistry initializes correctly with various parameters."""
+        # With token
+        registry = GitLabRegistry(
+            registry_url="https://gitlab.example.com",
+            project="test-project",
+            token="test-token",  # noqa: S106
+        )
+        assert registry.registry_url == "https://gitlab.example.com"
+        assert registry.project == "test-project"
+        assert registry.token == "test-token"  # noqa: S105
+        assert registry.headers == {"Authorization": "Bearer test-token"}
+
+    def test_gitlab_registry_initialization_without_token(self):
+        """Test that GitLabRegistry initializes correctly with various parameters."""
+        # Without token
+        registry = GitLabRegistry(
+            registry_url="https://gitlab.example.com",
+            project="test-project",
+        )
+        assert registry.token is None
+        assert not registry.headers
+
+    def test_gitlab_registry_name(self, gitlab_registry):
+        """Test that GitLabRegistry returns correct name."""
+        assert gitlab_registry.name == "GitLab (https://gitlab.example.com)"
+
+    def test_parse_link_header(self):
+        """Test that _parse_link_header correctly parses different link header formats."""
+        # Test with a standard link header format
+        link_header = '<https://gitlab.example.com/api/v4/projects/1/packages?page=2>; rel="next", <https://gitlab.example.com/api/v4/projects/1/packages?page=3>; rel="last"'
+        expected = {
+            "next": "https://gitlab.example.com/api/v4/projects/1/packages?page=2",
+            "last": "https://gitlab.example.com/api/v4/projects/1/packages?page=3",
+        }
+        # pylint: disable=W0212
+        assert GitLabRegistry._parse_link_header(link_header) == expected  # noqa: SLF001
+
+        # Test with no link header
+        # pylint: disable=W0212
+        assert not GitLabRegistry._parse_link_header("")  # noqa: SLF001
+
+        # Test with quoted relation values
+        link_header = '<https://gitlab.example.com/api/v4/projects/1/packages?page=2>; rel="next first"'
+        expected = {
+            "next": "https://gitlab.example.com/api/v4/projects/1/packages?page=2",
+            "first": "https://gitlab.example.com/api/v4/projects/1/packages?page=2",
+        }
+        assert GitLabRegistry._parse_link_header(link_header) == expected  # noqa: SLF001
+
+    @pytest.fixture(autouse=True)
+    def mock_urlopen(self, monkeypatch):  # noqa: C901
+        """Create a mock for urllib.request.urlopen."""
+
+        class MockResponse:
+            def __init__(self, data, headers=None):
+                self.data = data
+                self.headers = headers or {}
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def read(self):
+                return json.dumps(self.data).encode("utf-8")
+
+        def mock_urlopen(request):
+            # Mock different API responses based on the URL
+            url = request.get_full_url()
+
+            if url.split("?")[0].endswith("projects/test-project/packages"):
+                data = [
+                    {
+                        "id": 1,
+                        "name": "test-package",
+                        "version": "1.0.0",
+                    },
+                    {
+                        "id": 2,
+                        "name": "other-package",
+                        "version": "2.0.0",
+                    },
+                ]
+                return MockResponse(data)
+
+            if url.split("?")[0].endswith("packages/1/package_files"):
+                # Return files for test-package
+                data = [
+                    {
+                        "id": 101,
+                        "file_name": "test-package-1.0.0.tar.gz",
+                        "file_sha256": "correct_hash_value",
+                    },
+                    {
+                        "id": 102,
+                        "file_name": "test-package-1.0.0.whl",
+                        "file_sha256": "another_hash_value",
+                    },
+                ]
+                return MockResponse(data)
+
+            if url.split("?")[0].endswith("packages/2/package_files"):
+                # Return files for other-package
+                data = [
+                    {
+                        "id": 201,
+                        "file_name": "other-package-2.0.0.tar.gz",
+                        "file_sha256": "different_hash_value",
+                    },
+                ]
+                return MockResponse(data)
+
+            # Pagination test case page1
+            if "pagination-test" in url and "page=2" not in url:
+                # First page
+                data = [{"id": 1, "name": "page-1-item"}]
+                headers = {
+                    "Link": '<https://gitlab.example.com/api/v4/pagination-test?page=2&per_page=100>; rel="next"',
+                }
+                return MockResponse(data, headers)
+
+            # Pagination test case page2
+            if "pagination-test" in url and "page=2" in url:
+                # Second page
+                data = [{"id": 2, "name": "page-2-item"}]
+                return MockResponse(data)
+
+            msg = "Mock 404"
+            raise urllib.error.URLError(msg)
+
+        monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen)
+        return mock_urlopen
+
+    def test_fetch_packages_list(self, gitlab_registry):
+        """Test fetching the package list from the API."""
+        # pylint: disable=W0212
+        packages = gitlab_registry._fetch_packages_list()  # noqa: SLF001
+        assert len(packages) == 2
+        assert packages[0]["name"] == "test-package"
+        assert packages[1]["name"] == "other-package"
+
+        # Test that the result is cached
+        assert gitlab_registry._packages_cache is packages  # noqa: SLF001
+
+    def test_fetch_package_files(self, gitlab_registry):
+        """Test fetching package files from the API."""
+        # pylint: disable=W0212
+        files = gitlab_registry._fetch_package_files(1)  # noqa: SLF001
+        assert len(files) == 2
+        assert files[0]["file_name"] == "test-package-1.0.0.tar.gz"
+        assert files[1]["file_name"] == "test-package-1.0.0.whl"
+
+        # Test that the result is cached
+        assert gitlab_registry._package_files_cache[1] is files  # noqa: SLF001
+
+    def test_fetch_paginated_api(self, gitlab_registry):
+        """Test that pagination works correctly."""
+        # pylint: disable=W0212
+        result = gitlab_registry._fetch_paginated_api(  # noqa: SLF001
+            "https://gitlab.example.com/api/v4/pagination-test",
+        )
+        assert len(result) == 2
+        assert result[0]["name"] == "page-1-item"
+        assert result[1]["name"] == "page-2-item"
+
+    def test_has_package_with_matching_hash(self, gitlab_registry):
+        """Test has_package returns True when package exists with matching hash."""
+        result = gitlab_registry.has_package(
+            file_name="test-package-1.0.0.tar.gz",
+            package_name="test-package",
+            hash_alg="sha256",
+            expected_hash="correct_hash_value",
+        )
+        assert result is True
+
+    def test_has_package_with_non_existent_file(self, gitlab_registry):
+        """Test has_package returns True when package exists with matching hash."""
+        result = gitlab_registry.has_package(
+            file_name="test-package-99.0.0.tar.gz",
+            package_name="test-package",
+            hash_alg="sha256",
+            expected_hash="correct_hash_value",
+        )
+        assert result is False
+
+    def test_has_package_with_non_existent_package(self, gitlab_registry):
+        """Test has_package returns False when package doesn't exist."""
+        result = gitlab_registry.has_package(
+            file_name="non-existent-1.0.0.tar.gz",
+            package_name="non-existent",
+            hash_alg="sha256",
+            expected_hash="some_hash",
+        )
+        assert result is False
+
+    def test_has_package_with_mismatched_hash(self, gitlab_registry):
+        """Test has_package returns False when hash doesn't match."""
+        result = gitlab_registry.has_package(
+            file_name="test-package-1.0.0.tar.gz",
+            package_name="test-package",
+            hash_alg="sha256",
+            expected_hash="wrong_hash_value",
+        )
+        assert result is False
+
+    def test_has_package_with_unavailable_hash_alg(self, gitlab_registry):
+        """Test has_package returns False when the registry lacks the hash algorithm."""
+        result = gitlab_registry.has_package(
+            file_name="test-package-1.0.0.tar.gz",
+            package_name="test-package",
+            hash_alg="sha512",
+            expected_hash="some_hash_value",
+        )
+        assert result is False
+
+    # pylint: disable=W0212
+    def test_clear_cache(self, gitlab_registry):
+        """Test that clear_cache properly resets the cache."""
+        # Before filling, ensure cache is empty
+        assert gitlab_registry._packages_cache is None  # noqa: SLF001
+        assert gitlab_registry._package_files_cache == {}  # noqa: SLF001
+
+        # Fill the cache and verify it's populated
+        gitlab_registry._fetch_packages_list()  # noqa: SLF001
+        gitlab_registry._fetch_package_files(1)  # noqa: SLF001
+
+        assert gitlab_registry._packages_cache is not None  # noqa: SLF001
+        assert 1 in gitlab_registry._package_files_cache  # noqa: SLF001
+
+        # Clear the cache and verify it's reset
+        gitlab_registry.clear_cache()
+
+        assert gitlab_registry._packages_cache is None  # noqa: SLF001
+        assert gitlab_registry._package_files_cache == {}  # noqa: SLF001
+
+    def test_api_request_failure(self, gitlab_registry, monkeypatch):
+        """Test handling of API request failures."""
+
+        def failing_urlopen(_):
+            msg = "Mock connection error"
+            raise urllib.error.URLError(msg)
+
+        monkeypatch.setattr(urllib.request, "urlopen", failing_urlopen)
+
+        with pytest.raises(RuntimeError, match="Failed to read data"):
+            gitlab_registry._fetch_packages_list()  # noqa: SLF001
+
+    def test_file_url_in_next_link_raises_value_error(
+        self,
+        gitlab_registry,
+        monkeypatch,
+    ):
+        """Test that file:// URLs in Link header 'next' field raise ValueError."""
+
+        class MockResponse:
+            def __init__(self, data, headers=None):
+                self.data = data
+                self.headers = headers or {}
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def read(self):
+                return json.dumps(self.data).encode("utf-8")
+
+        def mock_urlopen_with_file_url(request):
+            # First request returns data with a malicious file:// URL in the next link
+            data = [{"id": 1, "name": "test-item"}]
+            headers = {
+                "Link": '<file:///etc/passwd>; rel="next"',
+            }
+            return MockResponse(data, headers)
+
+        monkeypatch.setattr(urllib.request, "urlopen", mock_urlopen_with_file_url)
+
+        # pylint: disable=W0212
+        with pytest.raises(ValueError, match="URL must start with 'http:' or 'https:'"):
+            gitlab_registry._fetch_paginated_api(  # noqa: SLF001
+                "https://gitlab.example.com/api/v4/test",
+            )


### PR DESCRIPTION
This PR contains two distinct features:

## PyPI for dependency resolution

This feature stops extracting and parsing the files from the local mirror, but instead uses PyPi's json API.
It is slower than local file parsing, but a lot less error-prone as the PyPi package parsing is very mature and constantly tested and verified.

## GitLab registry as index

This feature uses a Gitlab registry as a target registry instead of relying on a local file system structure.
It checks which packages are already present in the Gitlab registry and only fetches those that are still missing. All the missing packages can then be uploaded by tools like, e.g. twine after Morgan has finished mirroring.

As Gitlab doesn't have PyPi's json API to obtain package dependencies and fetching all files from the Gitlab registry is very expensive on larger registries, this feature only makes sense together with PyPi as a dependency resolution.


As this is a major feature, we also provide extensive tests for both the local-file registry as well as the Gitlab registry.
