### PR TITLE
fix: Skipping (take 3)

### DIFF
--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -147,16 +147,19 @@ class Mirrorer:
         if self._processed_pkgs.check(requirement):
             return None
 
-        # Check if requirement is relevant for any environment
-        if not is_requirement_relevant(requirement, self.envs.values()):
-            print(f"\tSkipping {requirement}, not relevant for any environment")
-            self._processed_pkgs.add(requirement)  # Mark as processed
-            return None
-
+        # Display the cause of 'Skipping...'
+        extras = None
         if required_by:
+            extras = required_by.extras
             print(f"[{required_by}]: {requirement}")
         else:
             print(f"{requirement}")
+
+        # Check if requirement is relevant for any environment
+        if not is_requirement_relevant(requirement, self.envs.values(), extras=extras):
+            print("\tSkipping, not relevant for any environment")
+            self._processed_pkgs.add(requirement)  # Mark as processed
+            return None
 
         data: dict | None = None
 


### PR DESCRIPTION
this ini:
```ini
[requirements]
pyjwt = [crypto]==2.10.1
```
results in:
```
[pyjwt[crypto]==2.10.1]: cryptography>=3.4.0; extra == "crypto"
        Skipping, not relevant for any environment
```
so the code needs to know about extras from pyjwt
(take 2: #80, take 1: #76)