### PR TITLE
get control over prereleases

### DIFF
--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -55,6 +55,7 @@ class Mirrorer:
         self.mirror_all_wheels: bool = args.mirror_all_wheels
         self.mirror_all_versions: bool = args.mirror_all_versions
         self.package_type_regex: str = args.package_type_regex
+        self.prerelease = args.prerelease
         self.config = configparser.ConfigParser(
             strict=False,
             dict_type=ListExtendingOrderedDict,
@@ -262,19 +263,22 @@ class Mirrorer:
     def _parse_version_and_tags_in_files(self, files: list[dict]) -> list[dict]:
         # parse versions and platform tags for each file
         for file in files:
+            fn = file["filename"]
             try:
-                if re.search(r"\.whl$", file["filename"]):
+                if fn.endswith(".whl"):
                     _, file["version"], ___, file["tags"] = (
-                        packaging.utils.parse_wheel_filename(file["filename"])
+                        packaging.utils.parse_wheel_filename(fn)
                     )
                     file["is_wheel"] = True
-                elif re.search(r"\.(tar\.gz|zip)$", file["filename"]):
+                elif fn.endswith((".tar.gz", ".zip")):
                     _, file["version"] = packaging.utils.parse_sdist_filename(
                         # fix: selenium-2.0-dev-9429.tar.gz -> 9429
-                        to_single_dash(file["filename"]),
+                        to_single_dash(fn),
                     )
                     file["is_wheel"] = False
                     file["tags"] = None
+                if file["version"].is_prerelease and not self.prerelease:
+                    continue
             except (  # noqa: PERF203
                 packaging.version.InvalidVersion,
                 packaging.utils.InvalidSdistFilename,
@@ -288,7 +292,7 @@ class Mirrorer:
                 # can ignore such files
                 continue
             except Exception:  # noqa: BLE001
-                print("\tSkipping file {}, exception caught".format(file["filename"]))
+                print(f"\tSkipping file {fn}, exception caught")
                 traceback.print_exc()
                 continue
         return files
@@ -449,7 +453,7 @@ class Mirrorer:
         if fileinfo.get("tags"):
             # At least one of the tags must match ALL of our environments
             for tag in fileinfo["tags"]:
-                (intrp_name, intrp_ver) = parse_interpreter(tag.interpreter)
+                intrp_name, intrp_ver = parse_interpreter(tag.interpreter)
                 if intrp_name not in ("py", "cp"):
                     continue
 
@@ -722,12 +726,7 @@ def mirror(args: argparse.Namespace):
         m.copy_server()
 
 
-def main():  # noqa: C901
-    """
-    Executes the command line interface of Morgan. Use -h for a full list of
-    flags, options and arguments.
-    """
-
+def create_arg_parser() -> argparse.ArgumentParser:
     def my_url(arg):
         # url -> url/ without params
         # https://stackoverflow.com/a/73719022
@@ -799,6 +798,11 @@ def main():  # noqa: C901
             "(default: fetch only the wheel for latest compatible Python version)"
         ),
     )
+    parser.add_argument(
+        "--prerelease",
+        action="store_true",
+        help="download prerelease too (dev, a, b, rc)",
+    )
 
     server.add_arguments(parser)
     configurator.add_arguments(parser)
@@ -816,6 +820,15 @@ def main():  # noqa: C901
         help="Command to execute",
     )
 
+    return parser
+
+
+def main():  # noqa: C901
+    """
+    Executes the command line interface of Morgan. Use -h for a full list of
+    flags, options and arguments.
+    """
+    parser = create_arg_parser()
     args = parser.parse_args()
 
     # These commands do not require a configuration file and therefore should

--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -279,7 +279,7 @@ class Mirrorer:
                     file["tags"] = None
                 if file["version"].is_prerelease and not self.prerelease:
                     continue
-            except (  # noqa: PERF203
+            except (
                 packaging.version.InvalidVersion,
                 packaging.utils.InvalidSdistFilename,
                 packaging.utils.InvalidWheelFilename,
@@ -823,7 +823,7 @@ def create_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main():  # noqa: C901
+def main():
     """
     Executes the command line interface of Morgan. Use -h for a full list of
     flags, options and arguments.

--- a/morgan/metadata.py
+++ b/morgan/metadata.py
@@ -295,7 +295,7 @@ class MetadataParser:
                             isinstance(marker[0], MarkerVariable)
                             and marker[0].value == "extra"
                         ):
-                            extra = marker[2].value
+                            extra = marker[2].value  # type: ignore[union-attr]
                             break
 
                 if extra:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
     "packaging~=24.0; python_version == '3.7'",
-    "packaging~=24.2; python_version >= '3.8'",
+    "packaging>=24.2; python_version >= '3.8'",
     "importlib-metadata~=4.12.0; python_version < '3.8'",
     "tomli~=2.0.1",
     "python-dateutil",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -96,8 +96,10 @@ class TestMirrorer:
         args = create_arg_parser().parse_args(
             [
                 "mirror",
-                "--index-path", str(temp_index_path),
-                "--config", os.path.join(temp_index_path, "morgan.ini"),
+                "--index-path",
+                str(temp_index_path),
+                "--config",
+                os.path.join(temp_index_path, "morgan.ini"),
             ],
         )
 
@@ -115,8 +117,10 @@ class TestMirrorer:
         args = create_arg_parser().parse_args(
             [
                 "mirror",
-                "--index-path", str(temp_index_path),
-                "--config", os.path.join(temp_index_path, "morgan.ini"),
+                "--index-path",
+                str(temp_index_path),
+                "--config",
+                os.path.join(temp_index_path, "morgan.ini"),
             ],
         )
         mirrorer = Mirrorer(args)
@@ -140,8 +144,10 @@ class TestMirrorer:
         args = create_arg_parser().parse_args(
             [
                 "mirror",
-                "--index-path", str(temp_index_path),
-                "--config", os.path.join(temp_index_path, "morgan.ini"),
+                "--index-path",
+                str(temp_index_path),
+                "--config",
+                os.path.join(temp_index_path, "morgan.ini"),
             ],
         )
         mirrorer = Mirrorer(args)
@@ -188,9 +194,12 @@ class TestFilterFiles:
         def _make_mirrorer(mirror_all_versions, mirror_all_wheels=False):
             argsL = [
                 "mirror",
-                "--index-path", str(temp_index_path),
-                "--index-url", "https://example.com/simple",
-                "--config", os.path.join(temp_index_path, "morgan.ini"),
+                "--index-path",
+                str(temp_index_path),
+                "--index-url",
+                "https://example.com/simple",
+                "--config",
+                os.path.join(temp_index_path, "morgan.ini"),
             ]
             if mirror_all_versions:
                 argsL.append("--mirror-all-versions")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,10 +10,10 @@ import pytest
 
 from morgan import (
     Mirrorer,
+    create_arg_parser,
     parse_interpreter,
     parse_requirement,
     server,
-    create_arg_parser,
 )
 
 
@@ -192,7 +192,7 @@ class TestFilterFiles:
     def make_mirrorer(self, temp_index_path):
         # Return a function that creates mirrorer instances
         def _make_mirrorer(mirror_all_versions, mirror_all_wheels=False):
-            argsL = [
+            args_list = [
                 "mirror",
                 "--index-path",
                 str(temp_index_path),
@@ -202,10 +202,10 @@ class TestFilterFiles:
                 os.path.join(temp_index_path, "morgan.ini"),
             ]
             if mirror_all_versions:
-                argsL.append("--mirror-all-versions")
+                args_list.append("--mirror-all-versions")
             if mirror_all_wheels:
-                argsL.append("--mirror-all-wheels")
-            args = create_arg_parser().parse_args(argsL)
+                args_list.append("--mirror-all-wheels")
+            args = create_arg_parser().parse_args(args_list)
             return Mirrorer(args)
 
         return _make_mirrorer

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,7 +1,6 @@
 # pylint: disable=missing-function-docstring,missing-class-docstring,missing-module-docstring
 from __future__ import annotations
 
-import argparse
 import hashlib
 import os
 
@@ -9,7 +8,13 @@ import packaging.requirements
 import packaging.version
 import pytest
 
-from morgan import PYPI_ADDRESS, Mirrorer, parse_interpreter, parse_requirement, server
+from morgan import (
+    Mirrorer,
+    parse_interpreter,
+    parse_requirement,
+    server,
+    create_arg_parser,
+)
 
 
 class TestParseInterpreter:
@@ -88,13 +93,12 @@ class TestMirrorer:
         return tmpdir
 
     def test_mirrorer_initialization(self, temp_index_path):
-        args = argparse.Namespace(
-            index_path=temp_index_path,
-            index_url="https://pypi.org/simple/",
-            config=os.path.join(temp_index_path, "morgan.ini"),
-            mirror_all_versions=False,
-            package_type_regex="(whl|zip|tar.gz)",
-            mirror_all_wheels=False,
+        args = create_arg_parser().parse_args(
+            [
+                "mirror",
+                "--index-path", str(temp_index_path),
+                "--config", os.path.join(temp_index_path, "morgan.ini"),
+            ],
         )
 
         mirrorer = Mirrorer(args)
@@ -108,13 +112,12 @@ class TestMirrorer:
         assert not mirrorer.mirror_all_versions
 
     def test_server_file_copying(self, temp_index_path):
-        args = argparse.Namespace(
-            index_path=temp_index_path,
-            index_url=PYPI_ADDRESS,
-            config=os.path.join(temp_index_path, "morgan.ini"),
-            mirror_all_versions=False,
-            package_type_regex="(whl|zip|tar.gz)",
-            mirror_all_wheels=False,
+        args = create_arg_parser().parse_args(
+            [
+                "mirror",
+                "--index-path", str(temp_index_path),
+                "--config", os.path.join(temp_index_path, "morgan.ini"),
+            ],
         )
         mirrorer = Mirrorer(args)
 
@@ -134,13 +137,12 @@ class TestMirrorer:
             )
 
     def test_file_hashing(self, temp_index_path):
-        args = argparse.Namespace(
-            index_path=temp_index_path,
-            index_url=PYPI_ADDRESS,
-            config=os.path.join(temp_index_path, "morgan.ini"),
-            mirror_all_versions=False,
-            package_type_regex="(whl|zip|tar.gz)",
-            mirror_all_wheels=False,
+        args = create_arg_parser().parse_args(
+            [
+                "mirror",
+                "--index-path", str(temp_index_path),
+                "--config", os.path.join(temp_index_path, "morgan.ini"),
+            ],
         )
         mirrorer = Mirrorer(args)
 
@@ -184,14 +186,17 @@ class TestFilterFiles:
     def make_mirrorer(self, temp_index_path):
         # Return a function that creates mirrorer instances
         def _make_mirrorer(mirror_all_versions, mirror_all_wheels=False):
-            args = argparse.Namespace(
-                index_path=temp_index_path,
-                index_url="https://example.com/simple",
-                config=os.path.join(temp_index_path, "morgan.ini"),
-                mirror_all_versions=mirror_all_versions,
-                package_type_regex=r"(whl|zip|tar\.gz)",
-                mirror_all_wheels=mirror_all_wheels,
-            )
+            argsL = [
+                "mirror",
+                "--index-path", str(temp_index_path),
+                "--index-url", "https://example.com/simple",
+                "--config", os.path.join(temp_index_path, "morgan.ini"),
+            ]
+            if mirror_all_versions:
+                argsL.append("--mirror-all-versions")
+            if mirror_all_wheels:
+                argsL.append("--mirror-all-wheels")
+            args = create_arg_parser().parse_args(argsL)
             return Mirrorer(args)
 
         return _make_mirrorer

--- a/tests/test_init_wheelscore.py
+++ b/tests/test_init_wheelscore.py
@@ -34,9 +34,12 @@ class TestCalculateScoresForWheel:
         args = create_arg_parser().parse_args(
             [
                 "mirror",
-                "--index-path", str(temp_index_path),
-                "--index-url", "https://example.com/simple",
-                "--config", os.path.join(temp_index_path, "morgan.ini"),
+                "--index-path",
+                str(temp_index_path),
+                "--index-url",
+                "https://example.com/simple",
+                "--config",
+                os.path.join(temp_index_path, "morgan.ini"),
                 "--mirror-all-wheels",
             ],
         )

--- a/tests/test_init_wheelscore.py
+++ b/tests/test_init_wheelscore.py
@@ -3,13 +3,12 @@
 # pylint: disable=missing-function-docstring,missing-class-docstring,protected-access
 # ruff: noqa: SLF001
 
-import argparse
 import os
 from typing import NamedTuple
 
 import pytest
 
-from morgan import Mirrorer
+from morgan import Mirrorer, create_arg_parser
 
 
 class TestCalculateScoresForWheel:
@@ -32,13 +31,14 @@ class TestCalculateScoresForWheel:
 
     @pytest.fixture
     def mirrorer(self, temp_index_path):
-        args = argparse.Namespace(
-            index_path=temp_index_path,
-            index_url="https://example.com/simple/",
-            config=os.path.join(temp_index_path, "morgan.ini"),
-            mirror_all_versions=False,
-            package_type_regex=r"(whl|zip|tar\.gz)",
-            mirror_all_wheels=True,
+        args = create_arg_parser().parse_args(
+            [
+                "mirror",
+                "--index-path", str(temp_index_path),
+                "--index-url", "https://example.com/simple",
+                "--config", os.path.join(temp_index_path, "morgan.ini"),
+                "--mirror-all-wheels",
+            ],
         )
         return Mirrorer(args)
 


### PR DESCRIPTION
Since v26 packaging changed the behaviour of Specifier.contains():
old: Specifier(">=1.2.3").contains("1.3.0a1") = False
new: True
So let's get control over prereleases