### PR TITLE
fix: TypeError when no sha256 hash is available

### DIFF
--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -556,7 +556,7 @@ class Mirrorer:
         hashalg = (
             PREFERRED_HASH_ALG
             if PREFERRED_HASH_ALG in fileinfo["hashes"]
-            else fileinfo["hashes"].keys()[0]
+            else next(iter(fileinfo["hashes"]))
         )
 
         self._download_file(fileinfo, filepath, hashalg)


### PR DESCRIPTION
dict_keys is not subscriptable; use next(iter(...)) to pick the fallback hash algorithm.