### PR TITLE
fix: escape project and file names in HTML index pages

### DIFF
--- a/morgan/server.py
+++ b/morgan/server.py
@@ -100,7 +100,7 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
                 self.wfile.write(
                     '    <a href="/{}/">{}</a>{}'.format(
                         html.escape(project["name"]),
-                        project["name"],
+                        html.escape(project["name"]),
                         newline,
                     ).encode("utf-8"),
                 )
@@ -163,18 +163,18 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
                 if not no_metadata and file.get("dist-info-metadata", False):
                     self.wfile.write(
                         '    <a href="{}{}" data-dist-info-metadata="true">{}</a>{}'.format(
-                            file["url"],
-                            hashval,
-                            file["filename"],
+                            html.escape(file["url"]),
+                            html.escape(hashval),
+                            html.escape(file["filename"]),
                             newline,
                         ).encode("utf-8"),
                     )
                 else:
                     self.wfile.write(
                         '    <a href="{}{}">{}</a>{}'.format(
-                            file["url"],
-                            hashval,
-                            file["filename"],
+                            html.escape(file["url"]),
+                            html.escape(hashval),
+                            html.escape(file["filename"]),
                             newline,
                         ).encode("utf-8"),
                     )


### PR DESCRIPTION
The project listing rendered the project name unescaped in the link text, and the per-project page rendered file URLs, hash fragments and file names entirely unescaped. File names originate from upstream index responses, so a malicious index could inject markup that executes when a user browses the mirror. Escape all dynamic values in HTML output.