### PR TITLE
fix: explicitly import dateutil.parser submodule

### DIFF
--- a/morgan/utils.py
+++ b/morgan/utils.py
@@ -5,7 +5,7 @@ import re
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Iterable
 
-import dateutil  # type: ignore[import-untyped]
+import dateutil.parser  # type: ignore[import-untyped]
 
 if TYPE_CHECKING:
     from packaging.requirements import Requirement


### PR DESCRIPTION
"import dateutil" does not import the parser submodule; accessing dateutil.parser only works on python-dateutil >= 2.9, which added lazy submodule imports via module __getattr__. With older versions, every touch_file() call (i.e. every downloaded file) crashes with AttributeError since python-dateutil is not pinned. Import the submodule explicitly, which works on all versions.