### PR TITLE
fix: explicitly import urllib.error

### DIFF
--- a/morgan/__init__.py
+++ b/morgan/__init__.py
@@ -9,6 +9,7 @@ import os.path
 import re
 import tarfile
 import traceback
+import urllib.error
 import urllib.parse
 import urllib.request
 import zipfile


### PR DESCRIPTION
The except clause in Mirrorer.mirror() references urllib.error, which was never imported. It only resolves because urllib.request happens to import urllib.error internally in CPython, which is an implementation detail. Import it explicitly.