### PR TITLE
ci: run LLM review via workflow_dispatch only

### DIFF
--- a/.github/workflows/pr-review-comprehensive.yml
+++ b/.github/workflows/pr-review-comprehensive.yml
@@ -1,37 +1,37 @@
-name: PR Review with Progress Tracking
-
-# This example demonstrates how to use the track_progress feature to get
-# visual progress tracking for PR reviews, similar to v0.x agent mode.
+name: PR Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+  # Reviews need to be run manually:
+  # Trigger from the Actions tab or with `gh workflow run`
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to review"
+        required: true
+        type: number
 
 jobs:
-  review-with-tracking:
+  review:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
-      - name: PR Review with Progress Tracking
+      - name: PR Review
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # Enable progress tracking
-          track_progress: true
 
           # Your custom review instructions
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ inputs.pr_number }}
 
             Perform a comprehensive code review with the following focus areas:
 
@@ -66,9 +66,3 @@ jobs:
           # Tools for comprehensive PR review
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
-
-# When track_progress is enabled:
-# - Creates a tracking comment with progress checkboxes
-# - Includes all PR context (comments, attachments, images)
-# - Updates progress as the review proceeds
-# - Marks as completed when done


### PR DESCRIPTION
Drop the pull_request/pull_request_target trigger and review PRs only when a maintainer manually dispatches the workflow with a PR number, keeping repository secrets away from untrusted fork PRs.

This intentionally drops automatic reviews even for trusted (non-fork) contributors: keeping two trigger paths, automatic for trusted PRs and manual for forks, would add complexity and make it less obvious when and why a review ran.

This supersedes and closes #102 