### PR TITLE
Add --comment flag to code review workflow

### DIFF
--- a/.github/workflows/pr-review-comprehensive.yml
+++ b/.github/workflows/pr-review-comprehensive.yml
@@ -62,6 +62,7 @@ jobs:
 
             Provide detailed feedback using inline comments for specific issues.
             Use top-level comments for general observations or praise.
+            --comment
 
           # Tools for comprehensive PR review
           claude_args: |


### PR DESCRIPTION
According to this issue https://github.com/anthropics/claude-code-action/issues/1523

Adding the `--comment` flag should fix the workflow